### PR TITLE
Fail build for lint warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - npm ci
 
 script:
-  - npx vue-cli-service lint --no-fix
+  - npx vue-cli-service lint --no-fix --max-warnings 0
   - npx vue-cli-service test:unit
 
 deploy:


### PR DESCRIPTION
Here's a suggestion to never allow any issues categorized as warnings from the linter - WDYT?