### PR TITLE
Interactive map

### DIFF
--- a/src/bigg.ts
+++ b/src/bigg.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import * as settings from "@/settings";
+
+export const lookupReaction = (reactionId: string) => {
+  // Return a reaction object with info from BiGG (returned in a delayed
+  // fashion)
+  const reaction: any = {
+    id: reactionId,
+    name: null,
+    reactionString: null
+  };
+  axios
+    .get(`${settings.apis.bigg}/universal/reactions/${reactionId}`)
+    .then(response => {
+      reaction.name = response.data.name;
+      reaction.reactionString = response.data.reaction_string;
+    })
+    .catch(error => {
+      reaction.name = "Unknown reaction";
+      reaction.reactionString = "N/A";
+    });
+  return reaction;
+};
+
+export const lookupGene = (modelId: string, geneId: string) => {
+  // Return a gene object with BiGG data (returned in a delayed fashion).
+  const gene: any = {
+    id: geneId,
+    name: null,
+    reactions: null
+  };
+  axios
+    .get(`${settings.apis.bigg}/models/${modelId}/genes/${geneId}`)
+    .then(response => {
+      gene.name = response.data.name;
+      gene.reactions = response.data.reactions;
+    })
+    .catch(error => {
+      gene.name = "Unknown gene";
+      gene.reactions = [];
+    });
+  return gene;
+};

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -162,8 +162,11 @@ export default Vue.extend({
     },
     modifications() {
       // Concatenate all modifications for a single table display.
-      // TODO: Added reactions
-      const addedReactions = [];
+      const reactionAdditions = this.card.reactionAdditions.map(reaction => ({
+        type: "Added reaction",
+        name: `${reaction.name} (${reaction.id})`,
+        details: "" // TODO: Reaction string
+      }));
       const reactionKnockouts = this.card.reactionKnockouts.map(reactionId => ({
         type: "Reaction knockout",
         name: `Name TBD (${reactionId})`, // TODO: Reaction name
@@ -180,7 +183,7 @@ export default Vue.extend({
         details: `Bounds set from ${bounds.lowerBound} to ${bounds.upperBound}`
       }));
       return [
-        ...addedReactions,
+        ...reactionAdditions,
         ...reactionKnockouts,
         ...geneKnockouts,
         ...editedBounds

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -138,19 +138,6 @@ export default Vue.extend({
   components: {
     CardDialog
   },
-  data: () => ({
-    methods: [
-      { id: "fba", name: "Flux Balance Analysis (FBA)" },
-      { id: "pfba", name: "Parsimonious FBA" },
-      { id: "fva", name: "Flux Variability Analysis (FVA)" },
-      { id: "pfba-fva", name: "Parsimonious FVA" }
-    ],
-    modificationsHeaders: [
-      { text: "Modifications", value: "type", sortable: false },
-      { text: "Name or ID", value: "id", sortable: false },
-      { text: "Details", value: "details", sortable: false }
-    ]
-  }),
   props: ["card", "isOnlyCard", "isSelected"],
   filters: {
     round(value) {

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -187,7 +187,13 @@ export default Vue.extend({
       if (this.card.objective.reaction.id === null) {
         return null;
       }
-      return this.card.fluxes[this.card.objective.reaction.id];
+      if (this.card.method === "fba" || this.card.method == "pfba") {
+        return this.card.fluxes[this.card.objective.reaction.id];
+      } else if (this.card.method === "fva" || this.card.method == "pfba-fva") {
+        // For FVA fluxes, calculate the average
+        const rxn = this.card.fluxes[this.card.objective.reaction.id];
+        return (rxn.upper_bound + rxn.lower_bound) / 2;
+      }
     },
     modifications() {
       // Concatenate all modifications for a single table display, and add a

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -157,6 +157,7 @@ export default Vue.extend({
 
         // Fetch and set the full model
         this.card.fullModel = null;
+        this.card.hasLoadModelError = false;
         if (this.card.model !== null) {
           axios
             .get(`${settings.apis.modelStorage}/models/${this.card.model.id}`)
@@ -164,8 +165,8 @@ export default Vue.extend({
               this.card.fullModel = response.data;
             })
             .catch(error => {
-              // TODO
-              console.log(error);
+              this.card.hasLoadModelError = true;
+              this.$emit("load-model-error");
             });
         }
       }
@@ -173,7 +174,7 @@ export default Vue.extend({
   },
   computed: {
     titleColor() {
-      if (this.card.hasSimulationError) {
+      if (this.card.hasSimulationError || this.card.hasLoadModelError) {
         return "error";
       } else if (this.isSelected) {
         return "primary";

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -170,6 +170,7 @@ export default Vue.extend({
         this.card.fullModel = null;
         this.card.hasLoadModelError = false;
         if (this.card.model !== null) {
+          this.card.isLoadingModel = true;
           axios
             .get(`${settings.apis.modelStorage}/models/${this.card.model.id}`)
             .then(response => {
@@ -178,6 +179,9 @@ export default Vue.extend({
             .catch(error => {
               this.card.hasLoadModelError = true;
               this.$emit("load-model-error");
+            })
+            .then(() => {
+              this.card.isLoadingModel = false;
             });
         }
       }

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -55,7 +55,9 @@
           <v-flex class="text-xs-right">
             <span v-if="card.objective.reactionId === null">Growth</span>
             <span v-else>{{ card.objective.reactionId }}</span>
-            <v-icon v-if="card.objective.maximize" size="16">arrow_upward</v-icon>
+            <v-icon v-if="card.objective.maximize" size="16"
+              >arrow_upward</v-icon
+            >
             <v-icon v-else size="16">arrow_downward</v-icon>
           </v-flex>
         </v-layout>

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -173,23 +173,32 @@ export default Vue.extend({
     modifications() {
       // Concatenate all modifications for a single table display.
       const reactionAdditions = this.card.reactionAdditions.map(reaction => ({
-        type: "Added reaction",
-        name: `${reaction.name} (${reaction.id})`,
+        type: "added_reaction",
+        typeDisplay: "Added reaction",
+        id: reaction.id,
+        name: reaction.name,
+        nameDisplay: `${reaction.name} (${reaction.id})`,
         details: "" // TODO: Reaction string
       }));
       const reactionKnockouts = this.card.reactionKnockouts.map(reactionId => ({
-        type: "Reaction knockout",
-        name: `Name TBD (${reactionId})`, // TODO: Reaction name
+        type: "reaction_knockout",
+        typeDisplay: "Reaction knockout",
+        id: reactionId,
+        nameDisplay: `Name TBD (${reactionId})`, // TODO: Reaction name
         details: ""
       }));
       const geneKnockouts = this.card.geneKnockouts.map(geneId => ({
-        type: "Gene knockout",
-        name: geneId,
+        type: "gene_knockout",
+        typeDisplay: "Gene knockout",
+        id: geneId,
+        nameDisplay: geneId,
         details: "" // Would be nice to show related reactions here.
       }));
       const editedBounds = this.card.editedBounds.map(bounds => ({
-        type: "Modified bounds",
-        name: `Name TBD (${bounds.reactionId})`, // TODO: Reaction name
+        type: "edited_bounds",
+        typeDisplay: "Modified bounds",
+        id: bounds.reactionId,
+        nameDisplay: `Name TBD (${bounds.reactionId})`, // TODO: Reaction name
         details: `Bounds set from ${bounds.lowerBound} to ${bounds.upperBound}`
       }));
       return [

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -14,6 +14,12 @@
         :card="card"
         :modifications="modifications"
         @simulate-card="simulateCard"
+        @open-method-help-dialog="showMethodHelpDialog = true"
+      />
+      <!-- Define the method help dialog here to avoid nested dialogs. -->
+      <MethodHelpDialog
+        :showMethodHelpDialog="showMethodHelpDialog"
+        @close-dialog="showMethodHelpDialog = false"
       />
 
       <v-btn flat icon v-if="!isOnlyCard" @click="removeCard">
@@ -133,12 +139,17 @@ import Vue from "vue";
 import axios from "axios";
 import * as settings from "@/settings";
 import CardDialog from "@/components/InteractiveMap/CardDialog.vue";
+import MethodHelpDialog from "@/components/InteractiveMap/MethodHelpDialog.vue";
 
 export default Vue.extend({
   name: "Card",
   components: {
-    CardDialog
+    CardDialog,
+    MethodHelpDialog
   },
+  data: () => ({
+    showMethodHelpDialog: false
+  }),
   props: ["card", "isOnlyCard", "isSelected"],
   filters: {
     round(value) {

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -103,7 +103,7 @@
           <v-flex class="text-xs-right" v-if="card.objective.reaction">
             <div v-if="!card.isSimulating">
               <span
-                v-if="card.growthRate !== null"
+                v-if="production != null"
                 :class="{ dead: production === 0 }"
               >
                 {{ production | round }}

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -42,9 +42,7 @@
         <v-flex class="xs6 text-xs-right">
           <span v-if="card.objective.reactionId === null">Growth</span>
           <span v-else>{{ card.objective.reactionId }}</span>
-          <v-icon v-if="card.objective.direction === 'max'" size="16"
-            >arrow_upward</v-icon
-          >
+          <v-icon v-if="card.objective.maximize" size="16">arrow_upward</v-icon>
           <v-icon v-else size="16">arrow_downward</v-icon>
         </v-flex>
         <v-flex class="xs6">Modifications:</v-flex>
@@ -72,13 +70,10 @@
             ></v-progress-circular>
           </div>
         </v-flex>
-        <v-flex class="xs6" v-if="card.objective.reactionId !== null"
+        <v-flex class="xs6" v-if="card.objective.reactionId"
           >{{ card.objective.reactionId }} flux:</v-flex
         >
-        <v-flex
-          class="xs6 text-xs-right"
-          v-if="card.objective.reactionId !== null"
-        >
+        <v-flex class="xs6 text-xs-right" v-if="card.objective.reactionId">
           <div v-if="!card.isSimulating">
             <span
               v-if="card.growthRate !== null"

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -21,81 +21,107 @@
       </v-btn>
     </v-toolbar>
     <v-card-title primary-title class="py-2" v-if="isSelected">
-      <v-layout wrap>
-        <v-flex class="xs6">Organism:</v-flex>
-        <v-flex class="xs6 text-xs-right">
-          <span v-if="card.organism">{{ card.organism.name }}</span>
-          <span v-else>
-            <em>Unknown</em>
-          </span>
-        </v-flex>
-        <v-flex class="xs6">Model:</v-flex>
-        <v-flex class="xs6 text-xs-right">
-          <span v-if="card.model">{{ card.model.name }}</span>
-          <span v-else>
-            <em>Not selected</em>
-          </span>
-        </v-flex>
-        <v-flex class="xs6">Method:</v-flex>
-        <v-flex class="xs6 text-xs-right">{{ card.method }}</v-flex>
-        <v-flex class="xs6">Objective:</v-flex>
-        <v-flex class="xs6 text-xs-right">
-          <span v-if="card.objective.reactionId === null">Growth</span>
-          <span v-else>{{ card.objective.reactionId }}</span>
-          <v-icon v-if="card.objective.maximize" size="16">arrow_upward</v-icon>
-          <v-icon v-else size="16">arrow_downward</v-icon>
-        </v-flex>
-        <v-flex class="xs6">Modifications:</v-flex>
-        <v-flex class="xs6 text-xs-right">{{ modifications.length }}</v-flex>
-        <v-flex class="xs6">Growth rate:</v-flex>
-        <v-flex class="xs6 text-xs-right">
-          <div v-if="!card.isSimulating">
-            <span
-              v-if="card.growthRate !== null"
-              :class="{ dead: card.growthRate === 0 }"
-            >
-              {{ card.growthRate | round }}
-              <em>
-                h
-                <sup>-1</sup>
-              </em>
+      <v-container fluid class="pa-0">
+        <v-layout>
+          <v-flex>Organism:</v-flex>
+          <v-flex class="text-xs-right">
+            <span v-if="card.organism">{{ card.organism.name }}</span>
+            <span v-else>
+              <em>Unknown</em>
             </span>
-            <span v-else>N/A</span>
-          </div>
-          <div v-else>
-            <v-progress-circular
-              indeterminate
-              size="12"
-              :width="1"
-            ></v-progress-circular>
-          </div>
-        </v-flex>
-        <v-flex class="xs6" v-if="card.objective.reactionId"
-          >{{ card.objective.reactionId }} flux:</v-flex
-        >
-        <v-flex class="xs6 text-xs-right" v-if="card.objective.reactionId">
-          <div v-if="!card.isSimulating">
-            <span
-              v-if="card.growthRate !== null"
-              :class="{ dead: production === 0 }"
-            >
-              {{ production | round }}
-              <em>
-                mmol/gDW/h
-                <sup>-1</sup>
-              </em>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout>
+          <v-flex>Model:</v-flex>
+          <v-flex class="text-xs-right">
+            <span v-if="card.model">{{ card.model.name }}</span>
+            <span v-else>
+              <em>Not selected</em>
             </span>
-            <span v-else>N/A</span>
-          </div>
-          <div v-else>
-            <v-progress-circular
-              indeterminate
-              size="12"
-              :width="1"
-            ></v-progress-circular>
-          </div>
-        </v-flex>
-      </v-layout>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout>
+          <v-flex>Method:</v-flex>
+          <v-flex class="text-xs-right">{{ card.method }}</v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout>
+          <v-flex>Objective:</v-flex>
+          <v-flex class="text-xs-right">
+            <span v-if="card.objective.reactionId === null">Growth</span>
+            <span v-else>{{ card.objective.reactionId }}</span>
+            <v-icon v-if="card.objective.maximize" size="16">arrow_upward</v-icon>
+            <v-icon v-else size="16">arrow_downward</v-icon>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout wrap>
+          <v-flex>Modifications:</v-flex>
+          <v-flex class="text-xs-right">{{ modifications.length }}</v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout wrap>
+          <v-flex>Growth rate:</v-flex>
+          <v-flex class="text-xs-right">
+            <div v-if="!card.isSimulating">
+              <span
+                v-if="card.growthRate !== null"
+                :class="{ dead: card.growthRate === 0 }"
+              >
+                {{ card.growthRate | round }}
+                <em>
+                  h
+                  <sup>-1</sup>
+                </em>
+              </span>
+              <span v-else>N/A</span>
+            </div>
+            <div v-else>
+              <v-progress-circular
+                indeterminate
+                size="12"
+                :width="1"
+              ></v-progress-circular>
+            </div>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container fluid class="pa-0">
+        <v-layout wrap>
+          <v-flex v-if="card.objective.reactionId"
+            >{{ card.objective.reactionId }} flux:</v-flex
+          >
+          <v-flex class="text-xs-right" v-if="card.objective.reactionId">
+            <div v-if="!card.isSimulating">
+              <span
+                v-if="card.growthRate !== null"
+                :class="{ dead: production === 0 }"
+              >
+                {{ production | round }}
+                <em>
+                  mmol/gDW/h
+                  <sup>-1</sup>
+                </em>
+              </span>
+              <span v-else>N/A</span>
+            </div>
+            <div v-else>
+              <v-progress-circular
+                indeterminate
+                size="12"
+                :width="1"
+              ></v-progress-circular>
+            </div>
+          </v-flex>
+        </v-layout>
+      </v-container>
     </v-card-title>
   </v-card>
 </template>

--- a/src/components/InteractiveMap/Card.vue
+++ b/src/components/InteractiveMap/Card.vue
@@ -193,6 +193,8 @@ export default Vue.extend({
         // For FVA fluxes, calculate the average
         const rxn = this.card.fluxes[this.card.objective.reaction.id];
         return (rxn.upper_bound + rxn.lower_bound) / 2;
+      } else {
+        throw new Error(`Unexpected simulation method ${this.card.method}`);
       }
     },
     modifications() {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -329,9 +329,9 @@ export default Vue.extend({
       } else {
         this.card.reactionAdditions.push(addedReaction);
       }
+      this.addReactionSearchQuery = null;
       this.$nextTick(() => {
         this.addReactionItem = null;
-        this.addReactionSearchQuery = null;
       });
     },
     knockoutReaction() {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -102,33 +102,34 @@
             :item-text="reactionDisplay"
             item-value="id"
             label="Add a reaction from BiGG..."
-            prepend-icon="get_app"
+            prepend-icon="add"
             return-object
             @change="addReaction"
           ></v-autocomplete>
 
           <v-autocomplete
             v-model="knockoutReactionItem"
-            :items="knockoutReactionSearchResults"
+            :items="reactions"
             :loading="isLoadingKnockoutReactions"
             hide-no-data
             :item-text="reactionDisplay"
             item-value="id"
             label="Knock out a reaction from the model..."
-            prepend-icon="clear"
+            prepend-icon="remove"
+            clearable
             return-object
             @change="knockoutReaction"
           ></v-autocomplete>
 
           <v-autocomplete
             v-model="knockoutGeneItem"
-            :items="knockoutGeneSearchResults"
+            :items="genes"
             :loading="isLoadingKnockoutGenes"
             hide-no-data
             item-text="id"
             item-value="id"
             label="Knock out a gene from the model..."
-            prepend-icon="clear"
+            prepend-icon="remove"
             return-object
             @change="knockoutGene"
           ></v-autocomplete>
@@ -232,12 +233,10 @@ export default Vue.extend({
     addedReactionExists: false,
     // Knockout reaction
     knockoutReactionItem: null,
-    knockoutReactionSearchResults: [], // TODO: Get reactions from the model
     isLoadingKnockoutReactions: false,
     knockoutReactionExists: false,
     // Knockout gene
     knockoutGeneItem: null,
-    knockoutGeneSearchResults: [], // TODO: Get genes from the model
     isLoadingKnockoutGenes: false,
     knockoutGeneExists: false,
     // Edit bounds
@@ -322,8 +321,6 @@ export default Vue.extend({
       return `${item.name} (${item.id})`;
     },
     addReaction(addedReaction) {
-      this.addReactionItem = null;
-      this.addReactionSearchQuery = null;
       const existingReaction = this.card.reactionAdditions.find(
         reaction => addedReaction.id === reaction.id
       );
@@ -332,30 +329,36 @@ export default Vue.extend({
       } else {
         this.card.reactionAdditions.push(addedReaction);
       }
+      this.$nextTick(() => {
+        this.addReactionItem = null;
+        this.addReactionSearchQuery = null;
+      });
     },
-    knockoutReaction(knockoutReaction) {
-      this.knockoutReactionItem = null;
-      this.knockoutReactionSearchQuery = null;
+    knockoutReaction() {
       const existingReaction = this.card.reactionKnockouts.find(
-        reaction => reaction.id === knockoutReaction.id
+        reaction => reaction === this.knockoutReactionItem
       );
       if (existingReaction !== undefined) {
         this.knockoutReactionExists = true;
       } else {
-        this.card.reactionAdditions.push(knockoutReaction);
+        this.card.reactionKnockouts.push(this.knockoutReactionItem);
       }
+      this.$nextTick(() => {
+        this.knockoutReactionItem = null;
+      });
     },
     knockoutGene(knockoutGene) {
-      this.knockoutGeneItem = null;
-      this.knockoutGeneSearchQuery = null;
       const existingGene = this.card.geneKnockouts.find(
-        gene => gene.id === knockoutGene.id
+        gene => gene === knockoutGene
       );
       if (existingGene !== undefined) {
         this.knockoutGeneExists = true;
       } else {
         this.card.geneKnockouts.push(knockoutGene);
       }
+      this.$nextTick(() => {
+        this.knockoutGeneItem = null;
+      });
     },
     editBounds() {
       if (this.editBoundsLowerBound > this.editBoundsUpperBound) {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -79,6 +79,7 @@
                 hint="When left empty, the objective is growth."
                 persistent-hint
                 placeholder="Specify any reaction as objective..."
+                prepend-icon="done"
                 return-object
                 clearable
               ></v-select>

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -294,15 +294,6 @@
       Could not search BiGG for reactions, please check your internet
       connection.
     </v-snackbar>
-    <v-snackbar color="error" v-model="addedReactionExists" :timeout="6000">
-      This reaction is already added.
-    </v-snackbar>
-    <v-snackbar color="error" v-model="knockoutReactionExists" :timeout="6000">
-      This reaction is already knocked out.
-    </v-snackbar>
-    <v-snackbar color="error" v-model="knockoutGeneExists" :timeout="6000">
-      This gene is already knocked out.
-    </v-snackbar>
     <v-snackbar color="error" v-model="hasInvalidBoundsError" :timeout="6000">
       The lower bound cannot be larger than the upper bound.
     </v-snackbar>
@@ -337,13 +328,10 @@ export default Vue.extend({
     addReactionSearchResults: [],
     isLoadingAddReaction: false,
     biggRequestError: false,
-    addedReactionExists: false,
     // Knockout reaction
     knockoutReactionItem: null,
-    knockoutReactionExists: false,
     // Knockout gene
     knockoutGeneItem: null,
-    knockoutGeneExists: false,
     // Edit bounds
     editBoundsReaction: null,
     editBoundsValid: false,
@@ -441,12 +429,8 @@ export default Vue.extend({
       return `${gene.name} (${gene.id})`;
     },
     addReaction(addedReaction) {
-      const existingReaction = this.card.reactionAdditions.find(
-        reaction => addedReaction.id === reaction.id
-      );
-      if (existingReaction !== undefined) {
-        this.addedReactionExists = true;
-      } else {
+      // Add the reaction only if it's not already added.
+      if (!this.card.reactionAdditions.some(r => r.id === addedReaction.id)) {
         this.card.reactionAdditions.push(addedReaction);
       }
       this.addReactionSearchQuery = null;
@@ -456,12 +440,8 @@ export default Vue.extend({
     },
     knockoutReaction() {
       const reaction = bigg.lookupReaction(this.knockoutReactionItem.id);
-      const existingReaction = this.card.reactionKnockouts.find(
-        r => r.id === reaction.id
-      );
-      if (existingReaction !== undefined) {
-        this.knockoutReactionExists = true;
-      } else {
+      // Add the reaction only if it's not already added.
+      if (!this.card.reactionKnockouts.some(r => r.id === reaction.id)) {
         this.card.reactionKnockouts.push(reaction);
       }
       this.$nextTick(() => {
@@ -473,10 +453,8 @@ export default Vue.extend({
         this.card.fullModel.model_serialized.id,
         this.knockoutGeneItem.id
       );
-      const existingGene = this.card.geneKnockouts.find(g => g.id === gene.id);
-      if (existingGene !== undefined) {
-        this.knockoutGeneExists = true;
-      } else {
+      // Add the gene only if it's not already added.
+      if (!this.card.geneKnockouts.some(g => g.id === gene.id)) {
         this.card.geneKnockouts.push(gene);
       }
       this.$nextTick(() => {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -263,7 +263,7 @@
                 <v-text-field
                   v-model="editBoundsLowerBound"
                   type="number"
-                  label="Number"
+                  label="Lower bound"
                   :rules="[editBoundsBoundRule]"
                 ></v-text-field>
               </v-flex>
@@ -271,7 +271,7 @@
                 <v-text-field
                   v-model="editBoundsUpperBound"
                   type="number"
-                  label="Number"
+                  label="Upper bound"
                   :rules="[editBoundsBoundRule]"
                 ></v-text-field>
               </v-flex>

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -41,6 +41,7 @@
                 item-value="id"
                 :hint="modificationsHint"
                 persistent-hint
+                :rules="[v => !!v || 'Please choose the metabolic model.']"
                 return-object
               ></v-select>
             </v-flex>

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -403,7 +403,7 @@ export default Vue.extend({
         });
     },
     editBoundsReaction(reaction) {
-      if (reaction === null) {
+      if (reaction === undefined) {
         return;
       }
       // Fill the default bounds from the reaction in the model for convenience

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -111,7 +111,6 @@
             v-model="knockoutReactionItem"
             :items="knockoutReactionSearchResults"
             :loading="isLoadingKnockoutReactions"
-            :search-input.sync="knockoutReactionSearchQuery"
             hide-no-data
             :item-text="reactionDisplay"
             item-value="id"
@@ -125,7 +124,6 @@
             v-model="knockoutGeneItem"
             :items="knockoutGeneSearchResults"
             :loading="isLoadingKnockoutGenes"
-            :search-input.sync="knockoutGeneSearchQuery"
             hide-no-data
             item-text="id"
             item-value="id"
@@ -188,13 +186,11 @@ export default Vue.extend({
     addedReactionExists: false,
     // Knockout reaction
     knockoutReactionItem: null,
-    knockoutReactionSearchQuery: null,
     knockoutReactionSearchResults: [], // TODO: Get reactions from the model
     isLoadingKnockoutReactions: false,
     knockoutReactionExists: false,
     // Knockout gene
     knockoutGeneItem: null,
-    knockoutGeneSearchQuery: null,
     knockoutGeneSearchResults: [], // TODO: Get genes from the model
     isLoadingKnockoutGenes: false,
     knockoutGeneExists: false

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -299,7 +299,7 @@
           <em>Simulating...</em>
         </span>
         <v-btn color="primary" @click="showDialog = false">
-          Visualize simulation
+          Close
         </v-btn>
       </v-card-actions>
     </v-card>

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -132,6 +132,39 @@
             return-object
             @change="knockoutGene"
           ></v-autocomplete>
+
+          <v-layout wrap>
+            <v-flex grow>
+              <v-autocomplete
+                v-model="editBoundsReaction"
+                :items="reactions"
+                :loading="isLoadingEditableBounds"
+                hide-no-data
+                item-text="id"
+                item-value="id"
+                label="Edit the bounds of a reaction..."
+                prepend-icon="vertical_align_center"
+                return-object
+              ></v-autocomplete>
+            </v-flex>
+            <v-flex shrink>
+              <v-text-field
+                v-model="lowerBound"
+                type="number"
+                label="Number"
+              ></v-text-field>
+            </v-flex>
+            <v-flex shrink>
+              <v-text-field
+                v-model="upperBound"
+                type="number"
+                label="Number"
+              ></v-text-field>
+            </v-flex>
+            <v-flex shrink>
+              <v-btn color="primary" @click="editBounds">Update</v-btn>
+            </v-flex>
+          </v-layout>
         </v-container>
       </v-form>
 
@@ -193,7 +226,12 @@ export default Vue.extend({
     knockoutGeneItem: null,
     knockoutGeneSearchResults: [], // TODO: Get genes from the model
     isLoadingKnockoutGenes: false,
-    knockoutGeneExists: false
+    knockoutGeneExists: false,
+    // Edit bounds
+    editBoundsReaction: null,
+    editBoundsLowerBound: null,
+    editBoundsUpperBound: null,
+    isLoadingEditableBounds: false
   }),
   props: ["card", "modifications"],
   watch: {
@@ -292,6 +330,25 @@ export default Vue.extend({
       } else {
         this.card.geneKnockouts.push(knockoutGene);
       }
+    },
+    editBounds() {
+      const existingModification = this.card.editedBounds.find(bounds => {
+        return bounds.reactionId === this.editBoundsReaction;
+      });
+      if (existingModification !== undefined) {
+        // Update the existing modification
+        existingModification.lowerBound = this.lowerBound;
+        existingModification.upperBound = this.upperBound;
+      } else {
+        this.card.editedBounds.push({
+          reactionId: this.editBoundsReaction,
+          lowerBound: this.lowerBound,
+          upperBound: this.upperBound
+        });
+      }
+      this.editBoundsReaction = null;
+      this.lowerBound = null;
+      this.upperBound = null;
     }
   }
 });

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -181,7 +181,7 @@
                 v-model="card.objective.reaction"
                 :item-text="reactionDisplay"
                 item-value="id"
-                hint="When left empty, the objective is growth."
+                :hint="objectiveHint"
                 persistent-hint
                 placeholder="Specify any reaction as objective..."
                 prepend-icon="done"
@@ -430,6 +430,13 @@ export default Vue.extend({
       } else {
         return null;
       }
+    },
+    objectiveHint() {
+      let objective = "growth";
+      if (this.card.model !== null) {
+        objective = this.card.model.default_biomass_reaction;
+      }
+      return `When left empty, the objective is ${objective}.`;
     },
     reactions() {
       if (this.card.fullModel === null) {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -179,7 +179,8 @@
               <v-autocomplete
                 label="Objective"
                 :items="reactions"
-                :loading="card.fullModel === null"
+                :loading="card.isLoadingModel"
+                :disabled="card.fullModel === null"
                 v-model="card.objective.reaction"
                 :item-text="reactionDisplay"
                 item-value="id"
@@ -223,7 +224,8 @@
           <v-autocomplete
             v-model="knockoutReactionItem"
             :items="reactions"
-            :loading="card.fullModel === null"
+            :loading="card.isLoadingModel"
+            :disabled="card.fullModel === null"
             hide-no-data
             :item-text="reactionDisplay"
             item-value="id"
@@ -237,7 +239,8 @@
           <v-autocomplete
             v-model="knockoutGeneItem"
             :items="genes"
-            :loading="card.fullModel === null"
+            :loading="card.isLoadingModel"
+            :disabled="card.fullModel === null"
             hide-no-data
             :item-text="reactionDisplay"
             item-value="id"
@@ -253,7 +256,8 @@
                 <v-autocomplete
                   v-model="editBoundsReaction"
                   :items="reactions"
-                  :loading="card.fullModel === null"
+                  :loading="card.isLoadingModel"
+                  :disabled="card.fullModel === null"
                   :rules="[editBoundsReactionRule]"
                   hide-no-data
                   :item-text="reactionDisplay"

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -80,6 +80,20 @@
             return-object
             @change="addReaction"
           ></v-autocomplete>
+
+          <v-autocomplete
+            v-model="knockoutReactionItem"
+            :items="knockoutReactionSearchResults"
+            :loading="isLoadingKnockoutReactions"
+            :search-input.sync="knockoutReactionSearchQuery"
+            hide-no-data
+            :item-text="reactionDisplay"
+            item-value="id"
+            label="Knock out a reaction from the model..."
+            prepend-icon="clear"
+            return-object
+            @change="knockoutReaction"
+          ></v-autocomplete>
         </v-container>
       </v-form>
 
@@ -93,9 +107,11 @@
       Could not search BiGG for reactions, please check your internet
       connection.
     </v-snackbar>
-
     <v-snackbar color="error" v-model="addedReactionExists" :timeout="6000">
       This reaction is already added.
+    </v-snackbar>
+    <v-snackbar color="error" v-model="knockoutReactionExists" :timeout="6000">
+      This reaction is already knocked out.
     </v-snackbar>
   </v-dialog>
 </template>
@@ -120,12 +136,19 @@ export default Vue.extend({
       { text: "Name or ID", value: "id", sortable: false },
       { text: "Details", value: "details", sortable: false }
     ],
+    // Add reaction
     addReactionItem: null,
     addReactionSearchQuery: null,
     addReactionSearchResults: [],
     isLoadingAddReaction: false,
     biggRequestError: false,
-    addedReactionExists: false
+    addedReactionExists: false,
+    // Knockout reaction
+    knockoutReactionItem: null,
+    knockoutReactionSearchQuery: null,
+    knockoutReactionSearchResults: [], // TODO: Get reactions from the model
+    isLoadingKnockoutReactions: false,
+    knockoutReactionExists: false
   }),
   props: ["card", "modifications"],
   watch: {
@@ -199,6 +222,18 @@ export default Vue.extend({
         this.addedReactionExists = true;
       } else {
         this.card.reactionAdditions.push(addedReaction);
+      }
+    },
+    knockoutReaction(knockoutReaction) {
+      this.knockoutReactionItem = null;
+      this.knockoutReactionSearchQuery = null;
+      const existingReaction = this.card.reactionKnockouts.find(
+        reaction => reaction.id === knockoutReaction.id
+      );
+      if (existingReaction !== undefined) {
+        this.knockoutReactionExists = true;
+      } else {
+        this.card.reactionAdditions.push(knockoutReaction);
       }
     }
   }

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -361,7 +361,10 @@ export default Vue.extend({
       });
     },
     editBounds() {
-      if (this.editBoundsLowerBound > this.editBoundsUpperBound) {
+      const lowerBound = parseInt(this.editBoundsLowerBound);
+      const upperBound = parseInt(this.editBoundsUpperBound);
+
+      if (lowerBound > upperBound) {
         this.hasInvalidBoundsError = true;
         return;
       }
@@ -371,13 +374,13 @@ export default Vue.extend({
       });
       if (existingModification !== undefined) {
         // Update the existing modification
-        existingModification.lowerBound = this.editBoundsLowerBound;
-        existingModification.upperBound = this.editBoundsUpperBound;
+        existingModification.lowerBound = lowerBound;
+        existingModification.upperBound = upperBound;
       } else {
         this.card.editedBounds.push({
           reactionId: this.editBoundsReaction,
-          lowerBound: this.editBoundsLowerBound,
-          upperBound: this.editBoundsUpperBound
+          lowerBound: lowerBound,
+          upperBound: upperBound
         });
       }
       this.$refs.editBoundsForm.reset();

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -206,6 +206,7 @@
             v-model="addReactionItem"
             :items="addReactionSearchResults"
             :loading="isLoadingAddReaction"
+            :disabled="card.fullModel === null"
             :search-input.sync="addReactionSearchQuery"
             hide-no-data
             :item-text="reactionDisplay"

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -59,11 +59,17 @@
             hide-actions
             :headers="modificationsHeaders"
             :items="modifications"
+            item-key="type + id"
           >
             <template v-slot:items="props">
-              <td>{{ props.item.type }}</td>
-              <td>{{ props.item.name }}</td>
+              <td>{{ props.item.typeDisplay }}</td>
+              <td>{{ props.item.nameDisplay }}</td>
               <td>{{ props.item.details }}</td>
+              <td>
+                <v-btn flat icon @click="clearModification(props.item)">
+                  <v-icon>delete</v-icon>
+                </v-btn>
+              </td>
             </template>
           </v-data-table>
 
@@ -385,6 +391,25 @@ export default Vue.extend({
         });
       }
       this.$refs.editBoundsForm.reset();
+    },
+    clearModification(modification) {
+      if (modification.type === "added_reaction") {
+        const index = this.card.reactionAdditions.findIndex(
+          reaction => reaction.id === modification.id
+        );
+        this.card.reactionAdditions.splice(index, 1);
+      } else if (modification.type === "reaction_knockout") {
+        const index = this.card.reactionKnockouts.indexOf(modification.id);
+        this.card.reactionKnockouts.splice(index, 1);
+      } else if (modification.type === "gene_knockout") {
+        const index = this.card.geneKnockouts.indexOf(modification.id);
+        this.card.geneKnockouts.splice(index, 1);
+      } else if (modification.type === "edited_bounds") {
+        const index = this.card.editedBounds.findIndex(
+          bounds => bounds.reactionId === modification.id
+        );
+        this.card.editedBounds.splice(index, 1);
+      }
     }
   }
 });

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -401,6 +401,14 @@ export default Vue.extend({
         .then(() => {
           this.isLoadingAddReaction = false;
         });
+    },
+    editBoundsReaction(reaction) {
+      if (reaction === null) {
+        return;
+      }
+      // Fill the default bounds from the reaction in the model for convenience
+      this.editBoundsLowerBound = reaction.lower_bound;
+      this.editBoundsUpperBound = reaction.upper_bound;
     }
   },
   computed: {

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -67,6 +67,32 @@
             </template>
           </v-data-table>
 
+          <!-- TODO get reactions from model -->
+          <v-layout wrap>
+            <v-flex grow>
+              <v-select
+                label="Objective"
+                :items="reactions"
+                v-model="card.objective.reactionId"
+                item-text="name"
+                item-value="id"
+                hint="When left empty, the objective is growth."
+                persistent-hint
+                placeholder="Specify any reaction as objective..."
+                return-object
+                clearable
+              ></v-select>
+            </v-flex>
+
+            <v-flex shrink>
+              <v-switch
+                v-model="card.objective.maximize"
+                color="primary"
+                :label="card.objective.maximize ? 'Maximize' : 'Minimize'"
+              ></v-switch>
+            </v-flex>
+          </v-layout>
+
           <v-autocomplete
             v-model="addReactionItem"
             :items="addReactionSearchResults"

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -188,6 +188,7 @@
                 return-object
                 clearable
                 @change="$emit('simulate-card')"
+                @click:clear="$nextTick(() => (card.objective.reaction = null))"
               ></v-autocomplete>
             </v-flex>
 

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -51,6 +51,7 @@
                 v-model="card.method"
                 item-text="name"
                 item-value="id"
+                @change="$emit('simulate-card')"
               ></v-select>
             </v-flex>
           </v-layout>
@@ -185,6 +186,7 @@
                 prepend-icon="done"
                 return-object
                 clearable
+                @change="$emit('simulate-card')"
               ></v-autocomplete>
             </v-flex>
 
@@ -193,6 +195,7 @@
                 v-model="card.objective.maximize"
                 color="primary"
                 :label="card.objective.maximize ? 'Maximize' : 'Minimize'"
+                @change="$emit('simulate-card')"
               ></v-switch>
             </v-flex>
           </v-layout>
@@ -286,7 +289,18 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="primary" @click="simulate">Simulate</v-btn>
+        <v-progress-circular
+          v-if="card.isSimulating"
+          indeterminate
+          size="12"
+          :width="1"
+        ></v-progress-circular>
+        <span v-if="card.isSimulating" class="mx-2">
+          <em>Simulating...</em>
+        </span>
+        <v-btn color="primary" @click="showDialog = false">
+          Visualize simulation
+        </v-btn>
       </v-card-actions>
     </v-card>
 
@@ -353,6 +367,9 @@ export default Vue.extend({
   }),
   props: ["card", "modifications"],
   watch: {
+    "card.model"() {
+      this.$emit("simulate-card");
+    },
     addReactionSearchQuery(query) {
       this.addReactionSearchResults = [];
       if (query === null || query.trim().length === 0) {
@@ -418,10 +435,6 @@ export default Vue.extend({
       // TODO: Choose a default preferred model.
       this.card.model = null;
     },
-    simulate() {
-      this.showDialog = false;
-      this.$emit("simulate-card");
-    },
     reactionDisplay(reaction) {
       return `${reaction.name} (${reaction.id})`;
     },
@@ -437,6 +450,7 @@ export default Vue.extend({
       this.$nextTick(() => {
         this.addReactionItem = null;
       });
+      this.$emit("simulate-card");
     },
     knockoutReaction() {
       const reaction = bigg.lookupReaction(this.knockoutReactionItem.id);
@@ -447,6 +461,7 @@ export default Vue.extend({
       this.$nextTick(() => {
         this.knockoutReactionItem = null;
       });
+      this.$emit("simulate-card");
     },
     knockoutGene() {
       const gene = bigg.lookupGene(
@@ -460,6 +475,7 @@ export default Vue.extend({
       this.$nextTick(() => {
         this.knockoutGeneItem = null;
       });
+      this.$emit("simulate-card");
     },
     editBounds() {
       const lowerBound = parseInt(this.editBoundsLowerBound);
@@ -484,6 +500,7 @@ export default Vue.extend({
         this.card.editedBounds.push(reaction);
       }
       this.$refs.editBoundsForm.reset();
+      this.$emit("simulate-card");
     },
     clearModification(modification) {
       if (modification.type === "added_reaction") {
@@ -503,6 +520,7 @@ export default Vue.extend({
         );
         this.card.editedBounds.splice(index, 1);
       }
+      this.$emit("simulate-card");
     }
   }
 });

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -51,6 +51,8 @@
                 v-model="card.method"
                 item-text="name"
                 item-value="id"
+                prepend-icon="help"
+                @click:prepend="$emit('open-method-help-dialog')"
                 @change="$emit('simulate-card')"
               ></v-select>
             </v-flex>

--- a/src/components/InteractiveMap/CardDialog.vue
+++ b/src/components/InteractiveMap/CardDialog.vue
@@ -94,6 +94,20 @@
             return-object
             @change="knockoutReaction"
           ></v-autocomplete>
+
+          <v-autocomplete
+            v-model="knockoutGeneItem"
+            :items="knockoutGeneSearchResults"
+            :loading="isLoadingKnockoutGenes"
+            :search-input.sync="knockoutGeneSearchQuery"
+            hide-no-data
+            item-text="id"
+            item-value="id"
+            label="Knock out a gene from the model..."
+            prepend-icon="clear"
+            return-object
+            @change="knockoutGene"
+          ></v-autocomplete>
         </v-container>
       </v-form>
 
@@ -112,6 +126,9 @@
     </v-snackbar>
     <v-snackbar color="error" v-model="knockoutReactionExists" :timeout="6000">
       This reaction is already knocked out.
+    </v-snackbar>
+    <v-snackbar color="error" v-model="knockoutGeneExists" :timeout="6000">
+      This gene is already knocked out.
     </v-snackbar>
   </v-dialog>
 </template>
@@ -148,7 +165,13 @@ export default Vue.extend({
     knockoutReactionSearchQuery: null,
     knockoutReactionSearchResults: [], // TODO: Get reactions from the model
     isLoadingKnockoutReactions: false,
-    knockoutReactionExists: false
+    knockoutReactionExists: false,
+    // Knockout gene
+    knockoutGeneItem: null,
+    knockoutGeneSearchQuery: null,
+    knockoutGeneSearchResults: [], // TODO: Get genes from the model
+    isLoadingKnockoutGenes: false,
+    knockoutGeneExists: false
   }),
   props: ["card", "modifications"],
   watch: {
@@ -234,6 +257,18 @@ export default Vue.extend({
         this.knockoutReactionExists = true;
       } else {
         this.card.reactionAdditions.push(knockoutReaction);
+      }
+    },
+    knockoutGene(knockoutGene) {
+      this.knockoutGeneItem = null;
+      this.knockoutGeneSearchQuery = null;
+      const existingGene = this.card.geneKnockouts.find(
+        gene => gene.id === knockoutGene.id
+      );
+      if (existingGene !== undefined) {
+        this.knockoutGeneExists = true;
+      } else {
+        this.card.geneKnockouts.push(knockoutGene);
       }
     }
   }

--- a/src/components/InteractiveMap/Escher.vue
+++ b/src/components/InteractiveMap/Escher.vue
@@ -97,7 +97,8 @@ export default Vue.extend({
         this.escherBuilder.set_reaction_data(null);
       } else {
         if (this.card.method === "fba" || this.card.method == "pfba") {
-          this.escherBuilder.set_reaction_data(this.fluxesFiltered);
+          const fluxesFiltered = this.fluxFilter(fluxes);
+          this.escherBuilder.set_reaction_data(fluxesFiltered);
           // Set FVA data with the current fluxes. This resets opacity in case a
           // previous FVA simulation has been set on the map.
           // TODO: We should improve the escher API here.
@@ -114,7 +115,8 @@ export default Vue.extend({
             const average = (rxn.upper_bound + rxn.lower_bound) / 2;
             fluxesAverage[reaction] = average;
           });
-          this.escherBuilder.set_reaction_data(this.fluxesFiltered);
+          const fluxesFiltered = this.fluxFilter(fluxesAverage);
+          this.escherBuilder.set_reaction_data(fluxesFiltered);
           // Set the FVA data for transparency visualization.
           this.escherBuilder.set_reaction_fva_data(fluxes);
         }
@@ -122,20 +124,21 @@ export default Vue.extend({
       this.escherBuilder._update_data(true, true);
     }
   },
-  computed: {
-    fluxesFiltered() {
+  methods: {
+    fluxFilter(fluxes) {
       // Exclude fluxes with very low non-zero values, in order to not shift
       // the escher color scale.
+      // Note that this is a method, not a computed property from the card
+      // fluxes, because the fluxes data structure will vary depending on the
+      // simulation method.
       const fluxesFiltered = {};
-      Object.keys(this.card.fluxes).forEach(rxn => {
-        if (Math.abs(this.card.fluxes[rxn]) > 1e-7) {
-          fluxesFiltered[rxn] = this.card.fluxes[rxn];
+      Object.keys(fluxes).forEach(rxn => {
+        if (Math.abs(fluxes[rxn]) > 1e-7) {
+          fluxesFiltered[rxn] = fluxes[rxn];
         }
       });
       return fluxesFiltered;
-    }
-  },
-  methods: {
+    },
     getObjectState(id: string, type: string) {
       if (this.card === null || this.card.fullModel === null) {
         return {

--- a/src/components/InteractiveMap/Escher.vue
+++ b/src/components/InteractiveMap/Escher.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="escher-container fill-height">
+  <div class="escher-container fill-height" @click="$emit('click')">
     <v-container
       fluid
       fill-height

--- a/src/components/InteractiveMap/Escher.vue
+++ b/src/components/InteractiveMap/Escher.vue
@@ -64,8 +64,31 @@ export default Vue.extend({
         loadMap();
       }
     },
-    // TODO: Watch added reactions
     // TODO: Watch highlight reactions (for data-driven simulations)
+    "card.fullModel": {
+      // Important note: This watcher *must* run before the
+      // `card.reactionAdditions` watcher below, because reactions added to the
+      // model must be available to Escher. Therefore, this watcher must be
+      // ordered first here.
+      deep: true,
+      handler(fullModel) {
+        if (this.card === null || fullModel === null) {
+          this.escherBuilder.load_model(null);
+        } else {
+          this.escherBuilder.load_model(fullModel.model_serialized);
+        }
+      }
+    },
+    "card.reactionAdditions"(reactionAdditions) {
+      if (this.card === null) {
+        this.escherBuilder.set_added_reactions([]);
+      } else {
+        this.escherBuilder.set_added_reactions(
+          reactionAdditions.filter(r => !r.id.startsWith("DM_")).map(r => r.id)
+        );
+      }
+      this.escherBuilder._update_data(true, true);
+    },
     "card.reactionKnockouts"(reactionKnockouts) {
       if (this.card === null) {
         this.escherBuilder.set_knockout_reactions([]);
@@ -83,13 +106,6 @@ export default Vue.extend({
         this.escherBuilder.set_knockout_genes(geneKnockouts.map(g => g.id));
       }
       this.escherBuilder._update_data(true, true);
-    },
-    "card.fullModel"(fullModel) {
-      if (this.card === null || fullModel === null) {
-        this.escherBuilder.load_model(null);
-      } else {
-        this.escherBuilder.load_model(fullModel.model_serialized);
-      }
     },
     "card.fluxes"(fluxes) {
       // Update the flux distribution

--- a/src/components/InteractiveMap/Escher.vue
+++ b/src/components/InteractiveMap/Escher.vue
@@ -150,7 +150,10 @@ export default Vue.extend({
         includedInModel: existsInModel,
         knockout: this.card.reactionKnockouts.includes(id),
         knockoutGenes: this.card.geneKnockouts.includes(id),
-        objective: this.card.objective,
+        objective: {
+          reactionId: this.card.objective.reactionId,
+          direction: this.card.objective.maximize ? "max" : "min"
+        },
         bounds: {
           // TODO: Check model
           lowerbound: -1,
@@ -182,18 +185,14 @@ export default Vue.extend({
       if (this.card.objective.reactionId === reactionId) {
         // This is already the objective; undo it and reset to growth
         this.card.objective.reactionId = null;
-        this.card.objective.direction = "max";
+        this.card.objective.maximize = true;
       } else {
         this.card.objective.reactionId = reactionId;
       }
       this.$emit("simulate-card", this.card);
     },
     setObjectiveDirection(reactionId: string) {
-      if (this.card.objective.direction === "max") {
-        this.card.objective.direction = "min";
-      } else {
-        this.card.objective.direction = "max";
-      }
+      this.card.objective.maximize = !this.card.objective.maximize;
       this.$emit("simulate-card", this.card);
     },
     editBounds(reactionId: string, lower: string, upper: string) {

--- a/src/components/InteractiveMap/Escher.vue
+++ b/src/components/InteractiveMap/Escher.vue
@@ -251,9 +251,12 @@ export default Vue.extend({
       this.$emit("simulate-card", this.card);
     },
     setObjective(reactionId: string) {
-      const reaction = this.lookupReaction(reactionId);
+      const reaction = bigg.lookupReaction(reactionId);
 
-      if (this.card.objective.reaction.id === reaction.id) {
+      if (
+        this.card.objective.reaction !== null &&
+        this.card.objective.reaction.id === reaction.id
+      ) {
         // This is already the objective; undo it and reset to growth
         this.card.objective.reaction = null;
         this.card.objective.maximize = true;

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -136,22 +136,11 @@ export default Vue.extend({
           const model1 = this.$store.getters["models/getModelById"](
             map1.model_id
           );
-          let model1Name;
-          if (model1) {
-            model1Name = model1.name;
-          } else {
-            model1Name = "Unknown model";
-          }
-
+          const model1Name = model1 ? model1.name : "Unknown model";
           const model2 = this.$store.getters["models/getModelById"](
             map2.model_id
           );
-          let model2Name;
-          if (model2) {
-            model2Name = model2.name;
-          } else {
-            model2Name = "Unknown model";
-          }
+          const model2Name = model2 ? model2.name : "Unknown model";
           return model1Name.localeCompare(model2Name);
         } else {
           return map1.name.localeCompare(map2.name);
@@ -167,13 +156,10 @@ export default Vue.extend({
           if (mapsWithHeaders.length !== 0) {
             mapsWithHeaders.push({ divider: true });
           }
-          let modelName;
-          try {
-            modelName = this.$store.getters["models/getModelById"](map.model_id)
-              .name;
-          } catch {
-            modelName = "Unknown model";
-          }
+          const model = this.$store.getters["models/getModelById"](
+            map.model_id
+          );
+          const modelName = model ? model.name : "Unknown model";
           mapsWithHeaders.push({ header: modelName });
         }
         mapsWithHeaders.push(map);

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -89,6 +89,9 @@
       Sorry, we were not able to complete the simulation successfully. Please
       try again in a few seconds, or contact us if the problem persists.
     </v-snackbar>
+    <v-snackbar color="error" v-model="hasLoadMapError" :timeout="6000">
+      The map could not be loaded. Please try again in a few moments.
+    </v-snackbar>
     <v-snackbar color="error" v-model="hasLoadModelError" :timeout="6000">
       The model could not be loaded, please try updating the card's model.
       Certain features will not work properly without the model.
@@ -121,6 +124,7 @@ export default Vue.extend({
     selectedCard: null,
     playingInterval: null,
     hasSimulationError: false,
+    hasLoadMapError: false,
     hasLoadModelError: false
   }),
   computed: {
@@ -191,14 +195,15 @@ export default Vue.extend({
       });
     },
     changeMap() {
-      // TODO: Get map from maps state lazy loader
+      this.hasLoadMapError = false;
       axios
         .get(`${settings.apis.maps}/maps/${this.currentMapId}`)
         .then(response => {
           this.mapData = response.data.map;
         })
         .catch(error => {
-          // TODO: show snackbar
+          this.mapData = null;
+          this.hasLoadMapError = true;
         });
     },
     addDefaultCard() {

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -81,12 +81,17 @@
           @select-card="selectCard"
           @remove-card="removeCard"
           @simulate-card="simulate"
+          @load-model-error="hasLoadModelError = true"
         />
       </v-container>
     </v-navigation-drawer>
     <v-snackbar color="error" v-model="hasSimulationError" :timeout="8000">
       Sorry, we were not able to complete the simulation successfully. Please
       try again in a few seconds, or contact us if the problem persists.
+    </v-snackbar>
+    <v-snackbar color="error" v-model="hasLoadModelError" :timeout="6000">
+      The model could not be loaded, please try updating the card's model.
+      Certain features will not work properly without the model.
     </v-snackbar>
   </div>
 </template>
@@ -115,7 +120,8 @@ export default Vue.extend({
     cards: [],
     selectedCard: null,
     playingInterval: null,
-    hasSimulationError: false
+    hasSimulationError: false,
+    hasLoadModelError: false
   }),
   computed: {
     maps() {
@@ -234,6 +240,7 @@ export default Vue.extend({
         editedBounds: [],
         isSimulating: false,
         hasSimulationError: false,
+        hasLoadModelError: false,
         growthRate: null,
         fluxes: null
       };

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -300,7 +300,23 @@ export default Vue.extend({
       }
 
       // Add card operations
-      // TODO: Reaction additions
+      const reactionAdditions = card.reactionAdditions.map(reaction => ({
+        operation: "add",
+        type: "reaction",
+        id: reaction.id,
+        data: {
+          id: reaction.id,
+          name: reaction.name,
+          lower_bound: reaction.lowerBound,
+          upper_bound: reaction.upperBound,
+          metabolites: Object.assign(
+            {},
+            ...reaction.metabolites.map(m => ({
+              [`${m.id}_${m.compartment}`]: m.charge
+            }))
+          )
+        }
+      }));
       const reactionKnockouts = card.reactionKnockouts.map(reaction => ({
         operation: "knockout",
         type: "reaction",
@@ -321,6 +337,7 @@ export default Vue.extend({
         }
       }));
       const operations = [
+        ...reactionAdditions,
         ...reactionKnockouts,
         ...geneKnockouts,
         ...editedBounds

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -222,9 +222,10 @@ export default Vue.extend({
         name: name,
         organism: organism,
         model: model,
+        fullModel: null,
         method: method,
         objective: {
-          reactionId: null,
+          reaction: null,
           maximize: true
         },
         reactionAdditions: [],
@@ -288,23 +289,23 @@ export default Vue.extend({
 
       // Add card operations
       // TODO: Reaction additions
-      const reactionKnockouts = card.reactionKnockouts.map(reactionId => ({
+      const reactionKnockouts = card.reactionKnockouts.map(reaction => ({
         operation: "knockout",
         type: "reaction",
-        id: reactionId
+        id: reaction.id
       }));
-      const geneKnockouts = card.geneKnockouts.map(geneId => ({
+      const geneKnockouts = card.geneKnockouts.map(gene => ({
         operation: "knockout",
         type: "gene",
-        id: geneId
+        id: gene.id
       }));
-      const editedBounds = card.editedBounds.map(bounds => ({
+      const editedBounds = card.editedBounds.map(reaction => ({
         operation: "modify",
         type: "reaction",
-        id: bounds.reactionId,
+        id: reaction.id,
         data: {
-          lower_bound: bounds.lowerBound,
-          upper_bound: bounds.upperBound
+          lower_bound: reaction.lowerBound,
+          upper_bound: reaction.upperBound
         }
       }));
       const operations = [
@@ -320,7 +321,9 @@ export default Vue.extend({
           model_id: card.model.id,
           method: card.method,
           operations: operations,
-          objective_id: card.objective.reactionId,
+          objective_id: card.objective.reaction
+            ? card.objective.reaction.id
+            : null,
           objective_direction: card.objective.maximize ? "max" : "min"
         })
         .then(response => {

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -225,7 +225,7 @@ export default Vue.extend({
         method: method,
         objective: {
           reactionId: null,
-          direction: "max"
+          maximize: true
         },
         reactionAdditions: [],
         reactionKnockouts: [],
@@ -321,7 +321,7 @@ export default Vue.extend({
           method: card.method,
           operations: operations,
           objective_id: card.objective.reactionId,
-          objective_direction: card.objective.direction
+          objective_direction: card.objective.maximize ? "max" : "min"
         })
         .then(response => {
           card.growthRate = response.data.growth_rate;

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -219,6 +219,7 @@ export default Vue.extend({
         name: name,
         organism: organism,
         model: model,
+        isLoadingModel: false,
         fullModel: null,
         method: method,
         objective: {

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -3,11 +3,23 @@
     <Escher
       @escher-loaded="escherLoaded"
       @simulate-card="simulate"
+      @click="isSidepanelOpen = false"
       :card="selectedCard"
       :mapData="mapData"
     />
     <Legend />
-    <v-navigation-drawer permanent right absolute>
+    <v-btn
+      color="primary"
+      small
+      fab
+      top
+      right
+      class="sidepanel-toggle"
+      @click="isSidepanelOpen = true"
+    >
+      <v-icon>apps</v-icon>
+    </v-btn>
+    <v-navigation-drawer v-model="isSidepanelOpen" right absolute hide-overlay>
       <v-container class="py-1">
         <v-select
           label="Selected Map"
@@ -96,6 +108,7 @@ export default Vue.extend({
     Legend
   },
   data: () => ({
+    isSidepanelOpen: true,
     escherBuilder: null,
     currentMapId: null,
     mapData: null,
@@ -339,3 +352,9 @@ export default Vue.extend({
   }
 });
 </script>
+
+<style scoped>
+.sidepanel-toggle {
+  position: absolute;
+}
+</style>

--- a/src/components/InteractiveMap/InteractiveMap.vue
+++ b/src/components/InteractiveMap/InteractiveMap.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
   computed: {
     maps() {
       // Sort maps by model name, then map name
-      const maps = this.$store.state.maps.maps;
+      const maps: any[] = [...this.$store.state.maps.maps];
       maps.sort((map1, map2) => {
         if (map1.model_id !== map2.model_id) {
           const model1 = this.$store.getters["models/getModelById"](
@@ -129,9 +129,9 @@ export default Vue.extend({
           } else {
             model2Name = "Unknown model";
           }
-          return model1Name > model2Name;
+          return model1Name.localeCompare(model2Name);
         } else {
-          return map1.name > map2.name;
+          return map1.name.localeCompare(map2.name);
         }
       });
 

--- a/src/components/InteractiveMap/MethodHelpDialog.vue
+++ b/src/components/InteractiveMap/MethodHelpDialog.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-dialog v-model="showMethodHelpDialogLocal" width="1200">
+    <v-card>
+      <v-card-title class="headline primary white--text" primary-title>
+        Constraint-based modeling
+      </v-card-title>
+
+      <v-card-text>
+        <p>
+          The following simulation methods predict metabolic fluxes that
+          optimize certain biological objectives, for example, growth yield.
+          They operate under the assumption that the organism’s metabolism is in
+          a dynamic equilibrium (pseudo steady-state): internal metabolite
+          concentrations are constant and production and consumption fluxes
+          perfectly balance each other.<br />
+          This is a reasonable assumption when the environment is constant (e.g.
+          in a <a href="https://en.wikipedia.org/wiki/Chemostat">chemostat</a>)
+          or there is nutrient excess (e.g. a microbial culture growing in
+          <a href="https://en.wikipedia.org/wiki/Bacterial_growth#Phases"
+            >exponential phase</a
+          >).
+        </p>
+        <p>
+          Physiological data (uptake and secretion rates, yields, growth rates,
+          C13 fluxes etc.) can all be readily integrated in the form of reaction
+          rate constraints. In the future, the integration of additional types
+          of omics data will be added.
+        </p>
+        <p>
+          You can find a comprehensive overview of constraint-based modeling and
+          its applications
+          <a
+            href="http://www.sciencedirect.com/science/article/pii/S0092867415005681?via%3Dihub"
+            >here</a
+          >.
+        </p>
+        <h3 class="title">Flux Balance Analysis (FBA)</h3>
+        <p>
+          Flux balance analysis optimizes a biological objective to predict a
+          distribution of metabolic fluxes. The default objective is the
+          maximization of growth rate.
+        </p>
+        <p><strong>Caveats</strong>:</p>
+        <ul class="mb-3">
+          <li>
+            In general, flux distributions predicted through FBA are not unique.
+            Uncertainties in the predicted fluxes can be assessed through
+            <a href="http://cobramethods.wikidot.com/flux-variability-analysis"
+              >Flux Variability Analysis</a
+            >
+            (see also below).
+          </li>
+          <li>
+            Biomass composition is assumed to be constant and growth-rate
+            independent.
+          </li>
+          <li>
+            The objective is optimization of growth yield and not growth rate.
+          </li>
+        </ul>
+        <h3 class="title">Parsimonious FBA (recommended)</h3>
+        <p>
+          In addition to maximizing growth yield (see FVA below),
+          <a href="http://cobramethods.wikidot.com/pfba"
+            >Parsimonious Flux Balance Analysis</a
+          >
+          (pFBA) will simultaneously minimize the sum of all fluxes which is a
+          proxy for minimizing enzyme expression.
+        </p>
+        <p><strong>Caveats</strong>:</p>
+        <ul class="mb-3">
+          <li>
+            Flux minimization is only a proxy for the minimization of protein
+            expression cost. For more accurate modeling approaches to proteome
+            allocation, please refer to the
+            <a
+              href="http://onlinelibrary.wiley.com/doi/10.15252/msb.20167411/abstract"
+              >GECKO</a
+            >
+            method (already supported for <em>S. cerevisae</em>) and
+            <a href="http://msb.embopress.org/content/9/1/693">ME</a> models
+            (which will be made available soon).
+          </li>
+        </ul>
+        <h3 class="title">Flux Variability Analysis (FVA)</h3>
+        <p>
+          In general, constraint-based modeling solutions will have many
+          alternative optima.
+          <a href="http://cobramethods.wikidot.com/flux-variability-analysis"
+            >Flux Variability Analysis</a
+          >
+          (FVA) allows the estimation of the uncertainty in flux predictions
+          computed by FBA. Uncertain reaction rates are highlighted using
+          transparency.
+        </p>
+        <h3 class="title">Parsimonious FVA</h3>
+        <p>
+          Similar to FVA, parsimonious FVA will estimate the uncertainty of flux
+          predictions computed by pFBA.
+        </p>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="primary" flat @click="$emit('close-dialog')">
+          I see, thanks!
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "MethodHelpDialog",
+  data: () => ({
+    showMethodHelpDialogLocal: false
+  }),
+  props: ["showMethodHelpDialog"],
+  watch: {
+    showMethodHelpDialog(value) {
+      this.showMethodHelpDialogLocal = value;
+    },
+    showMethodHelpDialogLocal(value) {
+      if (!value) {
+        this.$emit("close-dialog");
+      }
+    }
+  }
+});
+</script>

--- a/src/store/modules/maps.ts
+++ b/src/store/modules/maps.ts
@@ -14,7 +14,7 @@ export default {
   namespaced: true,
   state: {
     maps: [],
-    fetchRequest: null
+    mapsPromise: null
   },
   mutations: {
     setMaps(state, maps: MapItem[]) {
@@ -29,34 +29,24 @@ export default {
     delete(state, ids) {
       state.maps = state.maps.filter(map => !ids.includes(map.id));
     },
-    setFetchRequest(state, fetchRequest) {
-      state.fetchRequest = fetchRequest;
+    setMapsPromise(state, mapsPromise) {
+      state.mapsPromise = mapsPromise;
     }
   },
   actions: {
     fetchMaps({ commit }) {
-      const fetchRequest = axios
+      const mapsPromise = axios
         .get(`${settings.apis.maps}/maps`)
         .then((response: AxiosResponse<MapItem[]>) => {
           commit("setMaps", response.data);
         })
         .catch(error => {
           commit("setFetchError", error, { root: true });
-        })
-        .then(() => {
-          commit("setFetchRequest", null);
         });
-      commit("setFetchRequest", fetchRequest);
+      commit("setMapsPromise", mapsPromise);
     }
   },
   getters: {
-    onData: state => callback => {
-      if (state.fetchRequest !== null) {
-        state.fetchRequest.then(callback);
-      } else {
-        callback();
-      }
-    },
     getMapById: state => (id: number) => {
       return state.maps.find(map => map.id === id);
     }

--- a/src/store/modules/models.ts
+++ b/src/store/modules/models.ts
@@ -17,7 +17,7 @@ export default {
   namespaced: true,
   state: {
     models: [],
-    fetchRequest: null
+    modelsPromise: null
   },
   mutations: {
     setModels(state, models: ModelItem[]) {
@@ -32,24 +32,21 @@ export default {
     delete(state, ids) {
       state.models = state.models.filter(model => !ids.includes(model.id));
     },
-    setFetchRequest(state, fetchRequest) {
-      state.fetchRequest = fetchRequest;
+    setModelsPromise(state, modelsPromise) {
+      state.modelsPromise = modelsPromise;
     }
   },
   actions: {
     fetchModels({ commit }) {
-      const fetchRequest = axios
+      const modelsPromise = axios
         .get(`${settings.apis.modelStorage}/models`)
         .then((response: AxiosResponse<ModelItem[]>) => {
           commit("setModels", response.data);
         })
         .catch(error => {
           commit("setFetchError", error, { root: true });
-        })
-        .then(() => {
-          commit("setFetchRequest", null);
         });
-      commit("setFetchRequest", fetchRequest);
+      commit("setModelsPromise", modelsPromise);
     }
   },
   getters: {
@@ -59,13 +56,6 @@ export default {
         model = { name: "???" };
       }
       return model;
-    },
-    onData: state => callback => {
-      if (state.fetchRequest !== null) {
-        state.fetchRequest.then(callback);
-      } else {
-        callback();
-      }
     }
   }
 };

--- a/src/store/modules/organisms.ts
+++ b/src/store/modules/organisms.ts
@@ -13,7 +13,8 @@ export interface OrganismItem {
 export default {
   namespaced: true,
   state: {
-    organisms: []
+    organisms: [],
+    organismsPromise: null
   },
   mutations: {
     setOrganisms(state, organisms: OrganismItem[]) {
@@ -21,11 +22,14 @@ export default {
     },
     addOrganism(state, organism: OrganismItem) {
       state.organisms.push(organism);
+    },
+    setOrganismsPromise(state, organismsPromise) {
+      state.organismsPromise = organismsPromise;
     }
   },
   actions: {
     fetchOrganisms({ commit }) {
-      axios
+      const organismsPromise = axios
         .get(`${settings.apis.warehouse}/organisms`)
         .then((response: AxiosResponse<OrganismItem[]>) => {
           commit("setOrganisms", response.data);
@@ -33,6 +37,7 @@ export default {
         .catch(error => {
           commit("setFetchError", error, { root: true });
         });
+      commit("setOrganismsPromise", organismsPromise);
     }
   },
   getters: {


### PR DESCRIPTION
- [x] Feat: Close sidepanel on map focus, fab button to show
- [x] Bugfix: Red X for gene/reaction knockouts in Escher is now correctly synced (thanks @annasirunian)
- [x] Feat: Model is now loaded in Escher
    - Reactions on map that are not in the model highlighted in red
    - Default bounds (from the model) are shown on reaction hover
- [x] Feat: Model modifications in card dialog implemented
    - Set objective (searches through model reactions)
    - Toggle objective direction
    - Add reaction from BiGG universal model (note: all reactions are assumed to be reversible)
    - Knock out reactions (searches through model reactions)
    - Knock out genes (searches through model genes)
    - Edit bounds (searches through model reactions, prefills fields with default bounds)

Remaining:

- [ ] Data-driven cards