### PR TITLE
Utilize vuetify grid for nav drawer layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,137 +20,135 @@
         </template>
       </v-toolbar>
 
-      <v-navigation-drawer
-        v-model="drawer"
-        app
-        clipped
-        style="display:flex;flex-direction:column;"
-        class="elevation-6"
-      >
-        <v-list>
-          <v-list-tile to="/">
-            <v-list-tile-action>
-              <v-icon>home</v-icon>
-            </v-list-tile-action>
-
-            <v-list-tile-content>
-              <v-list-tile-title>Home</v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
-
-          <v-list-tile to="/interactive-map">
-            <v-list-tile-action>
-              <v-icon>$vuetify.icons.interactive_map</v-icon>
-            </v-list-tile-action>
-
-            <v-list-tile-content>
-              <v-list-tile-title>Interactive Map</v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
-
-          <v-tooltip bottom :disabled="isAuthenticated">
-            <v-list-tile
-              slot="activator"
-              to="/design"
-              :disabled="!isAuthenticated"
-            >
+      <v-navigation-drawer v-model="drawer" app clipped class="elevation-6">
+        <v-layout column justify-space-between fill-height>
+          <v-list>
+            <v-list-tile to="/">
               <v-list-tile-action>
-                <v-icon>edit</v-icon>
+                <v-icon>home</v-icon>
               </v-list-tile-action>
 
               <v-list-tile-content>
-                <v-list-tile-title>Design</v-list-tile-title>
+                <v-list-tile-title>Home</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
-            <span>
-              {{ $store.state.commonTooltipMessages.unauthenticated }}
-            </span>
-          </v-tooltip>
 
-          <v-tooltip bottom :disabled="isAuthenticated">
-            <v-list-tile
-              to="/jobs"
-              slot="activator"
-              :disabled="!isAuthenticated"
-            >
+            <v-list-tile to="/interactive-map">
               <v-list-tile-action>
-                <v-icon>hourglass_empty</v-icon>
+                <v-icon>$vuetify.icons.interactive_map</v-icon>
               </v-list-tile-action>
 
               <v-list-tile-content>
-                <v-list-tile-title>Jobs</v-list-tile-title>
+                <v-list-tile-title>Interactive Map</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
-            <span>
-              {{ $store.state.commonTooltipMessages.unauthenticated }}
-            </span>
-          </v-tooltip>
 
-          <v-tooltip bottom :disabled="isAuthenticated">
-            <v-list-tile
-              to="/designs"
-              slot="activator"
-              :disabled="!isAuthenticated"
-            >
+            <v-tooltip bottom :disabled="isAuthenticated">
+              <v-list-tile
+                slot="activator"
+                to="/design"
+                :disabled="!isAuthenticated"
+              >
+                <v-list-tile-action>
+                  <v-icon>edit</v-icon>
+                </v-list-tile-action>
+
+                <v-list-tile-content>
+                  <v-list-tile-title>Design</v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+              <span>
+                {{ $store.state.commonTooltipMessages.unauthenticated }}
+              </span>
+            </v-tooltip>
+
+            <v-tooltip bottom :disabled="isAuthenticated">
+              <v-list-tile
+                to="/jobs"
+                slot="activator"
+                :disabled="!isAuthenticated"
+              >
+                <v-list-tile-action>
+                  <v-icon>hourglass_empty</v-icon>
+                </v-list-tile-action>
+
+                <v-list-tile-content>
+                  <v-list-tile-title>Jobs</v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+              <span>
+                {{ $store.state.commonTooltipMessages.unauthenticated }}
+              </span>
+            </v-tooltip>
+
+            <v-tooltip bottom :disabled="isAuthenticated">
+              <v-list-tile
+                to="/designs"
+                slot="activator"
+                :disabled="!isAuthenticated"
+              >
+                <v-list-tile-action>
+                  <v-icon>device_hub</v-icon>
+                </v-list-tile-action>
+
+                <v-list-tile-content>
+                  <v-list-tile-title>Designs</v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+              <span>
+                {{ $store.state.commonTooltipMessages.unauthenticated }}</span
+              >
+            </v-tooltip>
+
+            <v-tooltip bottom :disabled="isAuthenticated">
+              <v-list-tile
+                to="/projects"
+                slot="activator"
+                :disabled="!isAuthenticated"
+              >
+                <v-list-tile-action>
+                  <v-icon>subject</v-icon>
+                </v-list-tile-action>
+
+                <v-list-tile-content>
+                  <v-list-tile-title>Projects</v-list-tile-title>
+                </v-list-tile-content>
+              </v-list-tile>
+              <span>
+                {{ $store.state.commonTooltipMessages.unauthenticated }}</span
+              >
+            </v-tooltip>
+
+            <v-list-tile to="/maps">
               <v-list-tile-action>
-                <v-icon>device_hub</v-icon>
+                <v-icon>map</v-icon>
               </v-list-tile-action>
 
               <v-list-tile-content>
-                <v-list-tile-title>Designs</v-list-tile-title>
+                <v-list-tile-title>Maps</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
-            <span>
-              {{ $store.state.commonTooltipMessages.unauthenticated }}</span
-            >
-          </v-tooltip>
 
-          <v-tooltip bottom :disabled="isAuthenticated">
-            <v-list-tile
-              to="/projects"
-              slot="activator"
-              :disabled="!isAuthenticated"
-            >
+            <v-list-tile to="/models">
               <v-list-tile-action>
-                <v-icon>subject</v-icon>
+                <v-icon>rounded_corner</v-icon>
               </v-list-tile-action>
 
               <v-list-tile-content>
-                <v-list-tile-title>Projects</v-list-tile-title>
+                <v-list-tile-title>Models</v-list-tile-title>
               </v-list-tile-content>
             </v-list-tile>
-            <span>
-              {{ $store.state.commonTooltipMessages.unauthenticated }}</span
+          </v-list>
+          <v-spacer></v-spacer>
+          <div>
+            <v-btn primary flat small to="/terms-of-service"
+              >Terms of Service</v-btn
             >
-          </v-tooltip>
-
-          <v-list-tile to="/maps">
-            <v-list-tile-action>
-              <v-icon>map</v-icon>
-            </v-list-tile-action>
-
-            <v-list-tile-content>
-              <v-list-tile-title>Maps</v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
-
-          <v-list-tile to="/models">
-            <v-list-tile-action>
-              <v-icon>rounded_corner</v-icon>
-            </v-list-tile-action>
-
-            <v-list-tile-content>
-              <v-list-tile-title>Models</v-list-tile-title>
-            </v-list-tile-content>
-          </v-list-tile>
-        </v-list>
-        <v-spacer></v-spacer>
-        <div>
-          <v-btn primary flat small to="/terms-of-service"
-            >Terms of Service</v-btn
-          >
-          <v-btn primary flat small to="/privacy-policy">Privacy Policy</v-btn>
-        </div>
+            <v-btn primary flat small to="/privacy-policy"
+              >Privacy Policy</v-btn
+            >
+          </div>
+        </v-layout>
       </v-navigation-drawer>
 
       <v-content>


### PR DESCRIPTION
Since we're using a material design framework, it's good practice to use the [built-in grid system](https://vuetifyjs.com/en/framework/grid), and avoid manual css tweaks as much as possible.

This PR replaces the following line from #31 https://github.com/DD-DeCaF/caffeine-vue/blob/e53fde5bd57053e10dc3143a89dd5024afdddcaa/src/App.vue#L27 with `<v-layout column justify-space-between fill-height>`.