### PR TITLE
Destructure slot props

### DIFF
--- a/src/views/Designs.vue
+++ b/src/views/Designs.vue
@@ -63,7 +63,7 @@
                 <td>{{ props.item.design.gene_knockouts.length }}</td>
               </tr>
             </template>
-            <template v-slot:expand="props">
+            <template v-slot:expand="{ item: design }">
               <tr>
                 <td>
                   <v-checkbox hide-details class="hidden"></v-checkbox>
@@ -74,25 +74,19 @@
                 <td align="rigth" width="15%">
                   <div class="link-list">
                     <div
-                      v-for="(reactionKnockin, index) in props.item.design
+                      v-for="(reactionKnockin, index) in design.design
                         .reaction_knockins"
                       :key="index"
                     >
                       <div v-if="index < 10">
                         <a
                           :href="
-                            reactionLink(
-                              reactionKnockin,
-                              props.item.method,
-                              true
-                            )
+                            reactionLink(reactionKnockin, design.method, true)
                           "
                           class="link"
                           target="_blank"
                         >
-                          {{
-                            getReactionId(reactionKnockin, props.item.method)
-                          }}
+                          {{ getReactionId(reactionKnockin, design.method) }}
                         </a>
                       </div>
                       <div
@@ -101,22 +95,16 @@
                       >
                         <a
                           :href="
-                            reactionLink(
-                              reactionKnockin,
-                              props.item.method,
-                              true
-                            )
+                            reactionLink(reactionKnockin, design.method, true)
                           "
                           class="link"
                           target="_blank"
                         >
-                          {{
-                            getReactionId(reactionKnockin, props.item.method)
-                          }}
+                          {{ getReactionId(reactionKnockin, design.method) }}
                         </a>
                       </div>
                     </div>
-                    <div v-if="props.item.design.reaction_knockins.length > 10">
+                    <div v-if="design.design.reaction_knockins.length > 10">
                       <a
                         @click="showAllReactionKnockins = true"
                         :hidden="showAllReactionKnockins"
@@ -130,18 +118,14 @@
                 <td align="rigth" width="15%">
                   <div class="link-list">
                     <div
-                      v-for="(reactionKnockout, index) in props.item.design
+                      v-for="(reactionKnockout, index) in design.design
                         .reaction_knockouts"
                       :key="index"
                     >
                       <div v-if="index < 10">
                         <a
                           :href="
-                            reactionLink(
-                              reactionKnockout,
-                              props.item.method,
-                              false
-                            )
+                            reactionLink(reactionKnockout, design.method, false)
                           "
                           class="link"
                           target="_blank"
@@ -155,11 +139,7 @@
                       >
                         <a
                           :href="
-                            reactionLink(
-                              reactionKnockout,
-                              props.item.method,
-                              false
-                            )
+                            reactionLink(reactionKnockout, design.method, false)
                           "
                           class="link"
                           target="_blank"
@@ -168,9 +148,7 @@
                         </a>
                       </div>
                     </div>
-                    <div
-                      v-if="props.item.design.reaction_knockouts.length > 10"
-                    >
+                    <div v-if="design.design.reaction_knockouts.length > 10">
                       <a
                         @click="showAllReactionKnockouts = true"
                         :hidden="showAllReactionKnockouts"
@@ -184,7 +162,7 @@
                 <td align="rigth" width="15%">
                   <div class="link-list">
                     <div
-                      v-for="(geneKnockout, index) in props.item.design
+                      v-for="(geneKnockout, index) in design.design
                         .gene_knockouts"
                       :key="index"
                     >
@@ -211,7 +189,7 @@
                         </a>
                       </div>
                     </div>
-                    <div v-if="props.item.design.gene_knockouts.length > 10">
+                    <div v-if="design.design.gene_knockouts.length > 10">
                       <a
                         @click="showAllGeneKnockouts = true"
                         :hidden="showAllGeneKnockouts"

--- a/src/views/InteractiveMap/CardDialog.vue
+++ b/src/views/InteractiveMap/CardDialog.vue
@@ -65,14 +65,14 @@
             :items="modifications"
             item-key="type + id"
           >
-            <template v-slot:items="props">
+            <template v-slot:items="{ item: modification }">
               <!-- Added reaction -->
-              <td v-if="props.item.type === 'added_reaction'">
-                Added reaction
+              <td v-if="modification.type === 'added_reaction'">
+                Added reaction {{ modification.id }}
               </td>
-              <td v-if="props.item.type === 'added_reaction'">
-                <span v-if="props.item.name !== null">
-                  {{ props.item.name }} ({{ props.item.id }})
+              <td v-if="modification.type === 'added_reaction'">
+                <span v-if="modification.name !== null">
+                  {{ modification.name }} ({{ modification.id }})
                 </span>
                 <v-progress-circular
                   v-else
@@ -81,10 +81,10 @@
                   :width="1"
                 ></v-progress-circular>
               </td>
-              <td v-if="props.item.type === 'added_reaction'">
+              <td v-if="modification.type === 'added_reaction'">
                 <span
-                  v-if="props.item.reactionString !== null"
-                  v-html="props.item.reactionString"
+                  v-if="modification.reactionString !== null"
+                  v-html="modification.reactionString"
                 />
                 <v-progress-circular
                   v-else
@@ -95,12 +95,12 @@
               </td>
 
               <!-- Reaction knockout -->
-              <td v-if="props.item.type === 'reaction_knockout'">
+              <td v-if="modification.type === 'reaction_knockout'">
                 Reaction knockout
               </td>
-              <td v-if="props.item.type === 'reaction_knockout'">
-                <span v-if="props.item.name !== null">
-                  {{ props.item.name }} ({{ props.item.id }})
+              <td v-if="modification.type === 'reaction_knockout'">
+                <span v-if="modification.name !== null">
+                  {{ modification.name }} ({{ modification.id }})
                 </span>
                 <v-progress-circular
                   v-else
@@ -109,10 +109,10 @@
                   :width="1"
                 ></v-progress-circular>
               </td>
-              <td v-if="props.item.type === 'reaction_knockout'">
+              <td v-if="modification.type === 'reaction_knockout'">
                 <span
-                  v-if="props.item.reactionString !== null"
-                  v-html="props.item.reactionString"
+                  v-if="modification.reactionString !== null"
+                  v-html="modification.reactionString"
                 />
                 <v-progress-circular
                   v-else
@@ -123,12 +123,12 @@
               </td>
 
               <!-- Gene knockout -->
-              <td v-if="props.item.type === 'gene_knockout'">
+              <td v-if="modification.type === 'gene_knockout'">
                 Gene knockout
               </td>
-              <td v-if="props.item.type === 'gene_knockout'">
-                <span v-if="props.item.name !== null">
-                  {{ props.item.name }} ({{ props.item.id }})
+              <td v-if="modification.type === 'gene_knockout'">
+                <span v-if="modification.name !== null">
+                  {{ modification.name }} ({{ modification.id }})
                 </span>
                 <v-progress-circular
                   v-else
@@ -137,11 +137,11 @@
                   :width="1"
                 ></v-progress-circular>
               </td>
-              <td v-if="props.item.type === 'gene_knockout'">
-                <span v-if="props.item.reactions !== null">
+              <td v-if="modification.type === 'gene_knockout'">
+                <span v-if="modification.reactions !== null">
                   <p
                     class="mb-0"
-                    v-for="reaction in props.item.reactions"
+                    v-for="reaction in modification.reactions"
                     :key="reaction.id"
                   >
                     {{ reaction.name }} ({{ reaction.bigg_id }})
@@ -156,19 +156,19 @@
               </td>
 
               <!-- Edited bounds -->
-              <td v-if="props.item.type === 'edited_bounds'">
+              <td v-if="modification.type === 'edited_bounds'">
                 Modified bounds
               </td>
-              <td v-if="props.item.type === 'edited_bounds'">
-                {{ props.item.name }} ({{ props.item.id }})
+              <td v-if="modification.type === 'edited_bounds'">
+                {{ modification.name }} ({{ modification.id }})
               </td>
-              <td v-if="props.item.type === 'edited_bounds'">
-                Bounds set from {{ props.item.lowerBound }} to
-                {{ props.item.upperBound }}
+              <td v-if="modification.type === 'edited_bounds'">
+                Bounds set from {{ modification.lowerBound }} to
+                {{ modification.upperBound }}
               </td>
 
               <td>
-                <v-btn flat icon @click="clearModification(props.item)">
+                <v-btn flat icon @click="clearModification(modification)">
                   <v-icon>delete</v-icon>
                 </v-btn>
               </td>

--- a/src/views/Jobs/Jobs.vue
+++ b/src/views/Jobs/Jobs.vue
@@ -10,30 +10,27 @@
           must-sort
           class="elevation-8"
         >
-          <template v-slot:items="props">
-            <td>{{ props.item.product_name }}</td>
+          <template v-slot:items="{ item: job }">
+            <td>{{ job.product_name }}</td>
             <td>
-              {{ organism(model(props.item.model_id).organism_id).name }}
+              {{ organism(model(job.model_id).organism_id).name }}
             </td>
-            <td>{{ model(props.item.model_id).name }}</td>
+            <td>{{ model(job.model_id).name }}</td>
             <td>
-              {{ props.item.status }}
+              {{ job.status }}
               <v-progress-circular
                 indeterminate
                 color="primary"
                 class="ml-2"
                 :width="3"
                 :size="25"
-                v-if="
-                  props.item.status === 'STARTED' ||
-                    props.item.status === 'PENDING'
-                "
+                v-if="job.status === 'STARTED' || job.status === 'PENDING'"
               ></v-progress-circular>
             </td>
-            <td>{{ props.item.created | moment("D MMM YYYY, HH:mm") }}</td>
+            <td>{{ job.created | moment("D MMM YYYY, HH:mm") }}</td>
             <td>
               <router-link
-                :to="{ name: 'jobDetails', params: { id: props.item.id } }"
+                :to="{ name: 'jobDetails', params: { id: job.id } }"
                 class="link"
                 ><v-btn color="primary" flat>Details</v-btn></router-link
               >

--- a/src/views/Maps.vue
+++ b/src/views/Maps.vue
@@ -23,31 +23,30 @@
           class="elevation-8"
           :pagination.sync="pagination"
         >
-          <template v-slot:items="props">
-            <td>{{ props.item.name }}</td>
-            <td>{{ getModel(props.item.model_id).name }}</td>
+          <template v-slot:items="{ item: map }">
+            <td>{{ map.name }}</td>
+            <td>{{ getModel(map.model_id).name }}</td>
             <td>
               <v-tooltip
                 bottom
-                :disabled="isAuthenticated && props.item.project_id !== null"
+                :disabled="isAuthenticated && map.project_id !== null"
               >
                 <div v-if="!isAuthenticated">
                   <span>
                     {{ $store.state.commonTooltipMessages.unauthenticated }}
                   </span>
                 </div>
-                <div v-else-if="props.item.project_id === null">
+                <div v-else-if="map.project_id === null">
                   <span>
                     {{ $store.state.commonTooltipMessages.publicData }}
                   </span>
                 </div>
                 <v-icon
                   slot="activator"
-                  @click="editItem(props.item)"
-                  :disabled="!isAuthenticated || props.item.project_id === null"
+                  @click="editItem(map)"
+                  :disabled="!isAuthenticated || map.project_id === null"
                   :class="{
-                    pointerDisabled:
-                      !isAuthenticated || props.item.project_id === null
+                    pointerDisabled: !isAuthenticated || map.project_id === null
                   }"
                 >
                   edit
@@ -55,25 +54,24 @@
               </v-tooltip>
               <v-tooltip
                 bottom
-                :disabled="isAuthenticated && props.item.project_id !== null"
+                :disabled="isAuthenticated && map.project_id !== null"
               >
                 <div v-if="!isAuthenticated">
                   <span>
                     {{ $store.state.commonTooltipMessages.unauthenticated }}
                   </span>
                 </div>
-                <div v-else-if="props.item.project_id === null">
+                <div v-else-if="map.project_id === null">
                   <span>
                     {{ $store.state.commonTooltipMessages.publicData }}
                   </span>
                 </div>
                 <v-icon
                   slot="activator"
-                  @click="deleteItem(props.item)"
-                  :disabled="!isAuthenticated || props.item.project_id === null"
+                  @click="deleteItem(map)"
+                  :disabled="!isAuthenticated || map.project_id === null"
                   :class="{
-                    pointerDisabled:
-                      !isAuthenticated || props.item.project_id === null
+                    pointerDisabled: !isAuthenticated || map.project_id === null
                   }"
                 >
                   delete

--- a/src/views/Models.vue
+++ b/src/views/Models.vue
@@ -25,30 +25,30 @@
           class="elevation-8"
           :pagination.sync="pagination"
         >
-          <template v-slot:items="props">
-            <td>{{ props.item.name }}</td>
+          <template v-slot:items="{ item: model }">
+            <td>{{ model.name }}</td>
             <td>
               <v-tooltip
                 bottom
-                :disabled="isAuthenticated && props.item.project_id !== null"
+                :disabled="isAuthenticated && model.project_id !== null"
               >
                 <div v-if="!isAuthenticated">
                   <span>
                     {{ $store.state.commonTooltipMessages.unauthenticated }}
                   </span>
                 </div>
-                <div v-else-if="props.item.project_id === null">
+                <div v-else-if="model.project_id === null">
                   <span>
                     {{ $store.state.commonTooltipMessages.publicData }}
                   </span>
                 </div>
                 <v-icon
                   slot="activator"
-                  @click="handler(props.item)"
-                  :disabled="!isAuthenticated || props.item.project_id === null"
+                  @click="handler(model)"
+                  :disabled="!isAuthenticated || model.project_id === null"
                   :class="{
                     pointerDisabled:
-                      !isAuthenticated || props.item.project_id === null
+                      !isAuthenticated || model.project_id === null
                   }"
                 >
                   edit
@@ -56,25 +56,25 @@
               </v-tooltip>
               <v-tooltip
                 bottom
-                :disabled="isAuthenticated && props.item.project_id !== null"
+                :disabled="isAuthenticated && model.project_id !== null"
               >
                 <div v-if="!isAuthenticated">
                   <span>
                     {{ $store.state.commonTooltipMessages.unauthenticated }}
                   </span>
                 </div>
-                <div v-else-if="props.item.project_id === null">
+                <div v-else-if="model.project_id === null">
                   <span>
                     {{ $store.state.commonTooltipMessages.publicData }}
                   </span>
                 </div>
                 <v-icon
                   slot="activator"
-                  @click="deleteItem(props.item)"
-                  :disabled="!isAuthenticated || props.item.project_id === null"
+                  @click="deleteItem(model)"
+                  :disabled="!isAuthenticated || model.project_id === null"
                   :class="{
                     pointerDisabled:
-                      !isAuthenticated || props.item.project_id === null
+                      !isAuthenticated || model.project_id === null
                   }"
                 >
                   delete

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -15,13 +15,13 @@
           class="elevation-8"
           :pagination.sync="pagination"
         >
-          <template v-slot:items="props">
-            <td>{{ props.item.name }}</td>
+          <template v-slot:items="{ item: project }">
+            <td>{{ project.name }}</td>
             <td>
-              <v-icon slot="activator" @click="editItem(props.item)">
+              <v-icon slot="activator" @click="editItem(project)">
                 edit
               </v-icon>
-              <v-icon slot="activator" @click="deleteItem(props.item)">
+              <v-icon slot="activator" @click="deleteItem(project)">
                 delete
               </v-icon>
             </td>


### PR DESCRIPTION
Using object destructuring in the v-slot field, combined with renaming
Vuetifys `item` to the appropriate object name, makes the related
templates a little more readable.

Note: I wasn't able to make `expanded` work with destructuring in the
items slot for the designs table.