### PR TITLE
Visualize designs

### DIFF
--- a/src/store/modules/designs.ts
+++ b/src/store/modules/designs.ts
@@ -11,9 +11,9 @@ export interface DesignItem {
         upper_bound: number;
       }
     ];
-    gene_knockouts: object[];
-    reaction_knockins: object[];
-    reaction_knockouts: object[];
+    gene_knockouts: any[];
+    reaction_knockins: any[];
+    reaction_knockouts: any[];
   };
   id: number;
   model_id: number;
@@ -44,7 +44,47 @@ export default {
       const designsPromise = axios
         .get(`${settings.apis.designStorage}/designs`)
         .then((response: AxiosResponse<DesignItem[]>) => {
-          commit("setDesigns", response.data);
+          commit(
+            "setDesigns",
+            response.data.map(design => ({
+              // Map snake_case to camelCase.
+              ...design,
+              design: {
+                reactionKnockins: design.design.reaction_knockins.map(r => ({
+                  ...r,
+                  lowerBound: r.lower_bound,
+                  upperBound: r.upper_bound,
+                  reactionString: r.reaction_string,
+                  metabolites: r.metabolites.map(m => ({
+                    ...m,
+                    compartmentId: m.compartment_id
+                  }))
+                })),
+                reactionKnockouts: design.design.reaction_knockouts.map(r => ({
+                  ...r,
+                  lowerBound: r.lower_bound,
+                  upperBound: r.upper_bound,
+                  reactionString: r.reaction_string,
+                  metabolites: r.metabolites.map(m => ({
+                    ...m,
+                    compartmentId: m.compartment_id
+                  }))
+                })),
+                geneKnockouts: design.design.gene_knockouts.map(g => ({
+                  ...g,
+                  reactions: g.reactions.map(r => ({
+                    ...r,
+                    geneReactionRule: r.gene_reaction_rule
+                  }))
+                })),
+                constraints: design.design.constraints.map(r => ({
+                  ...r,
+                  lowerBound: r.lower_bound,
+                  upperBound: r.upper_bound
+                }))
+              }
+            }))
+          );
         })
         .catch(error => {
           commit("setFetchError", error, { root: true });

--- a/src/store/modules/designs.ts
+++ b/src/store/modules/designs.ts
@@ -57,7 +57,7 @@ export default {
                   reactionString: r.reaction_string,
                   metabolites: r.metabolites.map(m => ({
                     ...m,
-                    compartmentId: m.compartment_id
+                    compartment: m.compartment_id
                   }))
                 })),
                 reactionKnockouts: design.design.reaction_knockouts.map(r => ({
@@ -67,7 +67,7 @@ export default {
                   reactionString: r.reaction_string,
                   metabolites: r.metabolites.map(m => ({
                     ...m,
-                    compartmentId: m.compartment_id
+                    compartment: m.compartment_id
                   }))
                 })),
                 geneKnockouts: design.design.gene_knockouts.map(g => ({

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -27,6 +27,7 @@ export interface Card {
   organism: OrganismItem;
   modelId: number;
   method: string;
+  dataDriven: boolean;
   // Design card fields
   objective: {
     reaction: Reaction;

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -14,7 +14,7 @@ export interface Gene {
 export interface Metabolite {
   id: string;
   name: string;
-  compartmentId: string;
+  compartment: string;
   stoichiometry: number;
 }
 
@@ -159,7 +159,7 @@ export default {
               metabolites: response.data.metabolites.map(m => ({
                 id: m.bigg_id,
                 name: m.name,
-                compartmentId: m.compartment_bigg_id,
+                compartment: m.compartment_bigg_id,
                 stoichiometry: m.stoichiometry
               }))
             });

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -168,7 +168,11 @@ export default {
             resolve({
               id: response.data.bigg_id,
               name: response.data.name,
-              reactions: response.data.reactions
+              reactions: response.data.reactions.map(r => ({
+                id: r.bigg_id,
+                name: r.name,
+                geneReactionRule: r.gene_reaction_rule
+              }))
             });
           });
       });

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -5,6 +5,12 @@ import * as settings from "@/utils/settings";
 import { OrganismItem } from "./organisms";
 import { ModelItem } from "./models";
 
+export interface Gene {
+  id: string;
+  name: string;
+  reactions: any[];
+}
+
 export interface Metabolite {
   id: string;
   name: string;

--- a/src/store/modules/models.ts
+++ b/src/store/modules/models.ts
@@ -10,6 +10,8 @@ export interface ModelItem {
   project_id: number;
   preferred_id: number;
   default_biomass_reaction: string;
+  // Note that `model_serialized` will not be retrieved before requested through
+  // the `withFullModel` action.
   model_serialized?: object;
 }
 
@@ -23,11 +25,18 @@ export default {
   namespaced: true,
   state: {
     models: [],
-    modelsPromise: null
+    modelsPromise: null,
+    // `fullModelPromises` contains the promises to request the full model,
+    // keyed by model id. See the `withFullModel` action.
+    fullModelPromises: {}
   },
   mutations: {
     setModels(state, models: ModelItem[]) {
       state.models = models;
+    },
+    setFullModel(state, model) {
+      const index = state.models.findIndex(m => m.id === model.id);
+      Vue.set(state.models, index, model);
     },
     editModel(state, payload: any) {
       Vue.set(state.models, payload.index, payload.item);
@@ -40,6 +49,9 @@ export default {
     },
     setModelsPromise(state, modelsPromise) {
       state.modelsPromise = modelsPromise;
+    },
+    setFullModelPromise(state, { modelId, promise }) {
+      Vue.set(state.fullModelPromises, modelId, promise);
     }
   },
   actions: {
@@ -47,12 +59,43 @@ export default {
       const modelsPromise = axios
         .get(`${settings.apis.modelStorage}/models`)
         .then((response: AxiosResponse<ModelItem[]>) => {
-          commit("setModels", response.data);
+          // Store the models, but initialize the missing `model_serialized`
+          // field to null.
+          commit(
+            "setModels",
+            response.data.map(model => ({
+              ...model,
+              model_serialized: null
+            }))
+          );
         })
         .catch(error => {
           commit("setFetchError", error, { root: true });
         });
       commit("setModelsPromise", modelsPromise);
+    },
+    withFullModel({ state, commit }, modelId) {
+      // Use this action's returned promise to run logic which needs the full
+      // model to be available. If requested for the first time it will be
+      // retrieved, and from then on stay cached in the store and returned
+      // instantly.
+      if (state.fullModelPromises[modelId]) {
+        return state.fullModelPromises[modelId];
+      } else {
+        const promise = new Promise((resolve, reject) => {
+          axios
+            .get(`${settings.apis.modelStorage}/models/${modelId}`)
+            .then(response => {
+              commit("setFullModel", response.data);
+              resolve(response.data);
+            })
+            .catch(error => {
+              commit("setFetchError", error, { root: true });
+              reject(error);
+            });
+        });
+        commit("setFullModelPromise", { modelId, promise });
+      }
     }
   },
   getters: {

--- a/src/views/Designs.vue
+++ b/src/views/Designs.vue
@@ -81,9 +81,9 @@
                     :size="15"
                   ></v-progress-circular>
                 </td>
-                <td>{{ props.item.design.reaction_knockins.length }}</td>
-                <td>{{ props.item.design.reaction_knockouts.length }}</td>
-                <td>{{ props.item.design.gene_knockouts.length }}</td>
+                <td>{{ props.item.design.reactionKnockins.length }}</td>
+                <td>{{ props.item.design.reactionKnockouts.length }}</td>
+                <td>{{ props.item.design.geneKnockouts.length }}</td>
               </tr>
             </template>
             <template v-slot:expand="{ item: design }">
@@ -98,7 +98,7 @@
                   <div class="link-list">
                     <div
                       v-for="(reactionKnockin, index) in design.design
-                        .reaction_knockins"
+                        .reactionKnockins"
                       :key="index"
                     >
                       <div v-if="index < 10">
@@ -127,7 +127,7 @@
                         </a>
                       </div>
                     </div>
-                    <div v-if="design.design.reaction_knockins.length > 10">
+                    <div v-if="design.design.reactionKnockins.length > 10">
                       <a
                         @click="showAllReactionKnockins = true"
                         :hidden="showAllReactionKnockins"
@@ -142,7 +142,7 @@
                   <div class="link-list">
                     <div
                       v-for="(reactionKnockout, index) in design.design
-                        .reaction_knockouts"
+                        .reactionKnockouts"
                       :key="index"
                     >
                       <div v-if="index < 10">
@@ -171,7 +171,7 @@
                         </a>
                       </div>
                     </div>
-                    <div v-if="design.design.reaction_knockouts.length > 10">
+                    <div v-if="design.design.reactionKnockouts.length > 10">
                       <a
                         @click="showAllReactionKnockouts = true"
                         :hidden="showAllReactionKnockouts"
@@ -186,7 +186,7 @@
                   <div class="link-list">
                     <div
                       v-for="(geneKnockout, index) in design.design
-                        .gene_knockouts"
+                        .geneKnockouts"
                       :key="index"
                     >
                       <div v-if="index < 10">
@@ -212,7 +212,7 @@
                         </a>
                       </div>
                     </div>
-                    <div v-if="design.design.gene_knockouts.length > 10">
+                    <div v-if="design.design.geneKnockouts.length > 10">
                       <a
                         @click="showAllGeneKnockouts = true"
                         :hidden="showAllGeneKnockouts"
@@ -250,9 +250,9 @@ export default Vue.extend({
       { text: "Name", value: "name", width: "20%" },
       { text: "Organism", value: "organism_id", width: "15%" },
       { text: "Model", value: "model_id", width: "15%" },
-      { text: "Added reactions", value: "reaction_knockins", width: "15%" },
-      { text: "Reaction knockouts", value: "reaction_knockouts", width: "15%" },
-      { text: "Gene knockouts", value: "gene_knockouts", width: "15%" }
+      { text: "Added reactions", value: "reactionKnockins", width: "15%" },
+      { text: "Reaction knockouts", value: "reactionKnockouts", width: "15%" },
+      { text: "Gene knockouts", value: "geneKnockouts", width: "15%" }
     ],
     pagination: {
       rowsPerPage: 10
@@ -262,9 +262,9 @@ export default Vue.extend({
     customSort(items, index, isDesc) {
       items.sort((a, b) => {
         if (
-          index === "reaction_knockins" ||
-          index === "reaction_knockouts" ||
-          index === "gene_knockouts"
+          index === "reactionKnockins" ||
+          index === "reactionKnockouts" ||
+          index === "geneKnockouts"
         ) {
           if (!isDesc) {
             return a["design"][index].length - b["design"][index].length;

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -181,17 +181,6 @@ export default Vue.extend({
     "card.model": {
       immediate: true,
       handler() {
-        // Reset all modifications when the selected model changes.
-        this.updateCard({
-          uuid: this.card.uuid,
-          props: {
-            reactionAdditions: [],
-            reactionKnockouts: [],
-            geneKnockouts: [],
-            editedBounds: []
-          }
-        });
-
         // Fetch and set the full model
         this.updateCard({
           uuid: this.card.uuid,

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -13,6 +13,7 @@
 
       <CardDialog
         :card="card"
+        :model="model"
         :modifications="modifications"
         @simulate-card="simulateCard"
         @open-method-help-dialog="showMethodHelpDialog = true"
@@ -44,7 +45,7 @@
         <v-layout>
           <v-flex>Model:</v-flex>
           <v-flex class="text-xs-right">
-            <span v-if="card.model">{{ card.model.name }}</span>
+            <span v-if="model">{{ model.name }}</span>
             <span v-else>
               <em>Not selected</em>
             </span>
@@ -178,48 +179,24 @@ export default Vue.extend({
     }
   },
   watch: {
-    "card.model": {
+    "card.modelId": {
       immediate: true,
       handler() {
-        // Fetch and set the full model
-        this.updateCard({
-          uuid: this.card.uuid,
-          props: { fullModel: null, hasLoadModelError: false }
-        });
-        if (this.card.model !== null) {
-          this.updateCard({
-            uuid: this.card.uuid,
-            props: { isLoadingModel: true }
-          });
-          axios
-            .get(`${settings.apis.modelStorage}/models/${this.card.model.id}`)
-            .then(response => {
-              this.updateCard({
-                uuid: this.card.uuid,
-                props: { fullModel: response.data }
-              });
-            })
-            .catch(error => {
-              this.updateCard({
-                uuid: this.card.uuid,
-                props: { hasLoadModelError: true }
-              });
-              this.$emit("load-model-error");
-            })
-            .then(() => {
-              this.updateCard({
-                uuid: this.card.uuid,
-                props: { isLoadingModel: false }
-              });
-            });
+        // Make sure that the full model is always available. There might be a
+        // delay before it arrives, but without triggering this, dependent code
+        // (for example the Escher logic to load the map) might end up waiting
+        // indefinitely for the full model.
+        if (!this.card.modelId) {
+          return;
         }
+        this.$store.dispatch("models/withFullModel", this.card.modelId);
       }
     }
   },
   computed: {
     titleColor() {
       if (this.isSelected) {
-        if (this.card.hasSimulationError || this.card.hasLoadModelError) {
+        if (this.card.hasSimulationError) {
           return "error";
         } else {
           return "primary";
@@ -268,6 +245,68 @@ export default Vue.extend({
         ...geneKnockouts,
         ...editedBounds
       ];
+    },
+    model() {
+      // Returns the modified model (original model + added reactions) for this
+      // card.
+      // TODO: This is duplicated logic, a very similar computed property exists
+      // in the Escher component.
+      const selectedModel = this.$store.getters["models/getModelById"](
+        this.card.modelId
+      );
+
+      if (!selectedModel || !selectedModel.model_serialized) {
+        return selectedModel;
+      }
+
+      // Create a copy of the model object to avoid references to the object in
+      // the store.
+      const model = {
+        ...selectedModel,
+        model_serialized: {
+          ...selectedModel.model_serialized
+        }
+      };
+      this.card.reactionAdditions.forEach(reaction => {
+        // Add the reaction to the model. (Take care to replace, not modify, the
+        // original array.)
+        model.model_serialized.reactions = [
+          ...model.model_serialized.reactions,
+          {
+            id: reaction.id,
+            name: reaction.name,
+            lower_bound: reaction.lowerBound,
+            upper_bound: reaction.upperBound,
+            gene_reaction_rule: "",
+            metabolites: Object.assign(
+              {},
+              ...reaction.metabolites.map(m => ({
+                [`${m.id}_${m.compartment}`]: m.stoichiometry
+              }))
+            )
+          }
+        ];
+
+        // Add any new metabolites from the reaction. (Take care to replace, not
+        // modify, the original array.)
+        const metabolites = reaction.metabolites
+          // Add the compartment postfix to the metabolite id
+          .map(metabolite => ({
+            ...metabolite,
+            id: `${metabolite.id}_${metabolite.compartment}`
+          }))
+          // Exclude metabolites that already exist in the model
+          .filter(metabolite => {
+            return !model.model_serialized.metabolites.some(
+              m => m.id === metabolite.id
+            );
+          });
+        model.model_serialized.metabolites = [
+          ...model.model_serialized.metabolites,
+          ...metabolites
+        ];
+      });
+      return model;
     }
   },
   methods: {
@@ -279,7 +318,7 @@ export default Vue.extend({
       this.$store.commit("interactiveMap/removeCard", this.card);
     },
     simulateCard() {
-      this.$emit("simulate-card", this.card);
+      this.$emit("simulate-card", this.card, this.model);
     },
     ...mapMutations({
       updateCard: "interactiveMap/updateCard"

--- a/src/views/InteractiveMap/CardDialog.vue
+++ b/src/views/InteractiveMap/CardDialog.vue
@@ -210,10 +210,17 @@ export default Vue.extend({
       this.updateCard({
         uuid: this.card.uuid,
         props: {
+          objective: {
+            reaction: null,
+            maximize: true
+          },
           reactionAdditions: [],
           reactionKnockouts: [],
           geneKnockouts: [],
-          editedBounds: []
+          editedBounds: [],
+          // Reset simulation results too
+          fluxes: null,
+          growthRate: null
         }
       });
       this.$emit("simulate-card");

--- a/src/views/InteractiveMap/CardDialog.vue
+++ b/src/views/InteractiveMap/CardDialog.vue
@@ -44,6 +44,7 @@
                 persistent-hint
                 :rules="[v => !!v || 'Please choose the metabolic model.']"
                 return-object
+                @change="onModelChange"
               ></v-select>
             </v-flex>
             <v-flex xs12 md3>
@@ -199,6 +200,24 @@ export default Vue.extend({
       this.updateCard({
         uuid: this.card.uuid,
         props: { model: null }
+      });
+      // Since the model was updated, trigger `onModelChange` to make sure card
+      // modifications are reset.
+      this.onModelChange();
+    },
+    onModelChange() {
+      // Reset all modifications when the selected model changes.
+      // Note: We cannot simply watch `card.model` with `immediate: true`,
+      // because that would reset modifications when cars are added from other
+      // components, i.e., when visualizing jobs or designs.
+      this.updateCard({
+        uuid: this.card.uuid,
+        props: {
+          reactionAdditions: [],
+          reactionKnockouts: [],
+          geneKnockouts: [],
+          editedBounds: []
+        }
       });
     },
     setLoadingOrganism(isLoading) {

--- a/src/views/InteractiveMap/CardDialog.vue
+++ b/src/views/InteractiveMap/CardDialog.vue
@@ -64,6 +64,7 @@
           <CardDialogDesign
             v-if="!card.dataDriven"
             :card="card"
+            :model="model"
             :modifications="modifications"
             @simulate-card="$emit('simulate-card')"
           />
@@ -103,6 +104,7 @@ import axios from "axios";
 import * as settings from "@/utils/settings";
 import CardDialogDesign from "@/views/InteractiveMap/CardDialogDesign.vue";
 import CardDialogDataDriven from "@/views/InteractiveMap/CardDialogDataDriven.vue";
+import { ModelItem } from "@/store/modules/models";
 
 export default Vue.extend({
   name: "CardDialog",
@@ -120,12 +122,7 @@ export default Vue.extend({
       { id: "pfba-fva", name: "Parsimonious FVA" }
     ]
   }),
-  props: ["card", "modifications"],
-  watch: {
-    "card.model"() {
-      this.$emit("simulate-card");
-    }
-  },
+  props: ["card", "model", "modifications"],
   computed: {
     organisms() {
       return this.$store.state.organisms.organisms;
@@ -171,12 +168,12 @@ export default Vue.extend({
     },
     cardModel: {
       get() {
-        return this.card.model;
+        return this.model;
       },
-      set(model) {
+      set(model: ModelItem) {
         this.updateCard({
           uuid: this.card.uuid,
-          props: { model: model }
+          props: { modelId: model.id }
         });
       }
     },
@@ -199,7 +196,7 @@ export default Vue.extend({
       // TODO: Choose a default preferred model.
       this.updateCard({
         uuid: this.card.uuid,
-        props: { model: null }
+        props: { modelId: null }
       });
       // Since the model was updated, trigger `onModelChange` to make sure card
       // modifications are reset.
@@ -207,8 +204,8 @@ export default Vue.extend({
     },
     onModelChange() {
       // Reset all modifications when the selected model changes.
-      // Note: We cannot simply watch `card.model` with `immediate: true`,
-      // because that would reset modifications when cars are added from other
+      // Note: We cannot simply watch `model` with `immediate: true`, because
+      // that would reset modifications when cards are added from other
       // components, i.e., when visualizing jobs or designs.
       this.updateCard({
         uuid: this.card.uuid,
@@ -219,6 +216,7 @@ export default Vue.extend({
           editedBounds: []
         }
       });
+      this.$emit("simulate-card");
     },
     setLoadingOrganism(isLoading) {
       this.isLoadingOrganism = isLoading;

--- a/src/views/InteractiveMap/CardDialogDesign.vue
+++ b/src/views/InteractiveMap/CardDialogDesign.vue
@@ -12,7 +12,7 @@
           Added reaction
         </td>
         <td v-if="modification.type === 'added_reaction'">
-          <span v-if="modification.name !== null">
+          <span v-if="modification.name">
             {{ modification.name }} ({{ modification.id }})
           </span>
           <v-progress-circular
@@ -24,7 +24,7 @@
         </td>
         <td v-if="modification.type === 'added_reaction'">
           <span
-            v-if="modification.reactionString !== null"
+            v-if="modification.reactionString"
             v-html="modification.reactionString"
           />
           <v-progress-circular
@@ -40,7 +40,7 @@
           Reaction knockout
         </td>
         <td v-if="modification.type === 'reaction_knockout'">
-          <span v-if="modification.name !== null">
+          <span v-if="modification.name">
             {{ modification.name }} ({{ modification.id }})
           </span>
           <v-progress-circular
@@ -52,7 +52,7 @@
         </td>
         <td v-if="modification.type === 'reaction_knockout'">
           <span
-            v-if="modification.reactionString !== null"
+            v-if="modification.reactionString"
             v-html="modification.reactionString"
           />
           <v-progress-circular
@@ -68,7 +68,7 @@
           Gene knockout
         </td>
         <td v-if="modification.type === 'gene_knockout'">
-          <span v-if="modification.name !== null">
+          <span v-if="modification.name">
             {{ modification.name }} ({{ modification.id }})
           </span>
           <v-progress-circular
@@ -79,13 +79,13 @@
           ></v-progress-circular>
         </td>
         <td v-if="modification.type === 'gene_knockout'">
-          <span v-if="modification.reactions !== null">
+          <span v-if="modification.reactions">
             <p
               class="mb-0"
               v-for="reaction in modification.reactions"
               :key="reaction.id"
             >
-              {{ reaction.name }} ({{ reaction.bigg_id }})
+              {{ reaction.name }} ({{ reaction.id }})
             </p>
           </span>
           <v-progress-circular
@@ -184,7 +184,7 @@
       :loading="model && !model.model_serialized"
       :disabled="!model"
       hide-no-data
-      :item-text="reactionDisplay"
+      :item-text="geneDisplay"
       item-value="id"
       label="Knock out a gene from the model..."
       prepend-icon="remove"

--- a/src/views/InteractiveMap/CardDialogDesign.vue
+++ b/src/views/InteractiveMap/CardDialogDesign.vue
@@ -121,8 +121,8 @@
         <v-autocomplete
           label="Objective"
           :items="reactions"
-          :loading="card.isLoadingModel"
-          :disabled="card.fullModel === null"
+          :loading="model && !model.model_serialized"
+          :disabled="!model"
           v-model="objectiveReaction"
           :item-text="reactionDisplay"
           item-value="id"
@@ -151,7 +151,7 @@
       v-model="addReactionItem"
       :items="addReactionSearchResults"
       :loading="isLoadingAddReaction"
-      :disabled="card.fullModel === null"
+      :disabled="!model"
       :search-input.sync="addReactionSearchQuery"
       hide-no-data
       :item-text="reactionDisplay"
@@ -166,8 +166,8 @@
     <v-autocomplete
       v-model="knockoutReactionItem"
       :items="reactions"
-      :loading="card.isLoadingModel"
-      :disabled="card.fullModel === null"
+      :loading="model && !model.model_serialized"
+      :disabled="!model"
       hide-no-data
       :item-text="reactionDisplay"
       item-value="id"
@@ -181,8 +181,8 @@
     <v-autocomplete
       v-model="knockoutGeneItem"
       :items="genes"
-      :loading="card.isLoadingModel"
-      :disabled="card.fullModel === null"
+      :loading="model && !model.model_serialized"
+      :disabled="!model"
       hide-no-data
       :item-text="reactionDisplay"
       item-value="id"
@@ -198,8 +198,8 @@
           <v-autocomplete
             v-model="editBoundsReaction"
             :items="reactions"
-            :loading="card.isLoadingModel"
-            :disabled="card.fullModel === null"
+            :loading="model && !model.model_serialized"
+            :disabled="!model"
             :rules="[editBoundsReactionRule]"
             hide-no-data
             :item-text="reactionDisplay"
@@ -289,11 +289,8 @@ export default Vue.extend({
     editBoundsLowerBound: null,
     editBoundsUpperBound: null
   }),
-  props: ["card", "modifications"],
+  props: ["card", "model", "modifications"],
   watch: {
-    "card.model"() {
-      this.$emit("simulate-card");
-    },
     addReactionSearchQuery(query) {
       this.addReactionSearchResults = [];
       if (query === null || query.trim().length === 0) {
@@ -306,17 +303,23 @@ export default Vue.extend({
           `${settings.apis.bigg}/search?query=${query}&search_type=reactions`
         )
         .then(response => {
-          this.addReactionSearchResults = response.data.results
-            .map(reaction => ({
-              id: reaction.bigg_id,
-              name: reaction.name
-            }))
-            // Exclude results that already exist in the current model
-            .filter(reaction =>
-              this.card.fullModel.model_serialized.reactions.every(
-                r => r.id !== reaction.id
-              )
-            );
+          // Wait for the full model to be able to filter out results that
+          // already exist in the model.
+          this.$store
+            .dispatch("models/withFullModel", this.model.id)
+            .then(model => {
+              this.addReactionSearchResults = response.data.results
+                .map(reaction => ({
+                  id: reaction.bigg_id,
+                  name: reaction.name
+                }))
+                // Exclude results that already exist in the current model
+                .filter(reaction =>
+                  model.model_serialized.reactions.every(
+                    r => r.id !== reaction.id
+                  )
+                );
+            });
         })
         .catch(error => {
           this.biggRequestError = true;
@@ -345,22 +348,22 @@ export default Vue.extend({
   computed: {
     objectiveHint() {
       let objective = "growth";
-      if (this.card.model !== null) {
-        objective = this.card.model.default_biomass_reaction;
+      if (this.model) {
+        objective = this.model.default_biomass_reaction;
       }
       return `When left empty, the objective is ${objective}.`;
     },
     reactions() {
-      if (this.card.fullModel === null) {
+      if (!this.model || !this.model.model_serialized) {
         return [];
       }
-      return this.card.fullModel.model_serialized.reactions;
+      return this.model.model_serialized.reactions;
     },
     genes() {
-      if (this.card.fullModel === null) {
+      if (!this.model || !this.model.model_serialized) {
         return [];
       }
-      return this.card.fullModel.model_serialized.genes;
+      return this.model.model_serialized.genes;
     },
     objectiveReaction: {
       get() {

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -4,7 +4,7 @@
       fluid
       fill-height
       class="overlay"
-      v-if="initializingEscher !== null || isLoadingMap"
+      v-if="initializingEscher || isLoadingMap"
     >
       <v-layout align-center justify-center>
         <v-progress-circular
@@ -15,7 +15,7 @@
           color="white"
         ></v-progress-circular>
         <p class="display-1 white--text mb-0">
-          <span v-if="initializingEscher !== null">Initializing Escher...</span>
+          <span v-if="initializingEscher">Initializing Escher...</span>
           <span v-else-if="isLoadingMap">Loading map...</span>
         </p>
       </v-layout>
@@ -38,7 +38,8 @@ export default Vue.extend({
   props: ["mapData", "card"],
   data: () => ({
     escherBuilder: null,
-    initializingEscher: null,
+    initializingEscher: true,
+    onEscherReady: null,
     isLoadingMap: false,
     hasBoundsError: false
   }),
@@ -64,11 +65,7 @@ export default Vue.extend({
       };
 
       // Wait for escher to initialize before loading the map.
-      if (this.initializingEscher !== null) {
-        this.initializingEscher.then(loadMap);
-      } else {
-        loadMap();
-      }
+      this.onEscherReady.then(loadMap);
     },
     model: {
       // Whenever the model (with local modifications) changes, update it in
@@ -426,7 +423,7 @@ export default Vue.extend({
     }
   },
   mounted() {
-    this.initializingEscher = new Promise((resolve, reject) => {
+    this.onEscherReady = new Promise((resolve, reject) => {
       this.escherBuilder = escher.Builder(null, null, null, this.$refs.escher, {
         menu: "zoom",
         scroll_behavior: "zoom",
@@ -453,7 +450,7 @@ export default Vue.extend({
         zoom_extent_canvas: true,
         first_load_callback: () => {
           resolve();
-          this.initializingEscher = null;
+          this.initializingEscher = false;
           this.$emit("escher-loaded");
         },
         reaction_state: this.getObjectState,

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -174,7 +174,7 @@ export default Vue.extend({
       }
     },
     setReactionAdditions() {
-      if (this.card === null) {
+      if (!this.card || !this.model || !this.model.model_serialized) {
         this.escherBuilder.set_added_reactions([]);
       } else {
         this.escherBuilder.set_added_reactions(

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -54,8 +54,7 @@ export default Vue.extend({
           this.escherBuilder.load_map(value);
           this.isLoadingMap = false;
           // Update the map state, since it will be reset whenever the map is
-          // changed.
-          this.setFullModel();
+          // changed. Note that we don't need to update the model.
           this.setReactionAdditions();
           this.setReactionKnockouts();
           this.setGeneKnockouts();

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -75,26 +75,26 @@ export default Vue.extend({
       // model must be available to Escher.
       deep: true,
       handler() {
-        this.setModel();
+        this.onEscherReady.then(this.setModel);
       }
     },
     // Add separate watchers for the different properties on the card, instead
     // of a single deep watcher on the card, to be able to only update the
     // relevant portions of the map.
     "card.reactionAdditions"() {
-      this.setReactionAdditions();
+      this.onEscherReady.then(this.setReactionAdditions);
     },
     "card.reactionKnockouts"() {
-      this.setReactionKnockouts();
+      this.onEscherReady.then(this.setReactionKnockouts);
     },
     "card.geneKnockouts"() {
-      this.setGeneKnockouts();
+      this.onEscherReady.then(this.setGeneKnockouts);
     },
     "card.conditionData"() {
-      this.setConditionData();
+      this.onEscherReady.then(this.setConditionData);
     },
     "card.fluxes"() {
-      this.setFluxes();
+      this.onEscherReady.then(this.setFluxes);
     }
   },
   computed: {

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -195,14 +195,19 @@ export default Vue.extend({
   methods: {
     escherLoaded() {
       if (this.$store.state.interactiveMap.cards.length > 0) {
-        // Card have been added (user might be visualizing jobs or existing
-        // designs), so select the last card in the list.
+        // There are already cards in the store - ensure they are all simulated
+        // (cards added from other components won't initially be simulated)
+        this.$store.state.interactiveMap.cards.forEach(card => {
+          this.simulate(card);
+        });
+        // Select the last card in the list by default.
         this.selectedCard = this.$store.state.interactiveMap.cards[
           this.$store.state.interactiveMap.cards.length - 1
         ];
       } else {
-        // Otherwise, add a default card. Chain promises to ensure that data is
-        // available.
+        // No cards are added at this point, so add a default card to provide
+        // the user with some initial data. Chain promises to ensure that data
+        // is available.
         this.$store.state.models.modelsPromise.then(() => {
           this.$store.state.organisms.organismsPromise.then(() => {
             this.addDefaultCard(false);

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -194,12 +194,21 @@ export default Vue.extend({
   },
   methods: {
     escherLoaded() {
-      // Add a default card. Chain promises to ensure that data is available.
-      this.$store.state.models.modelsPromise.then(() => {
-        this.$store.state.organisms.organismsPromise.then(() => {
-          this.addDefaultCard(false);
+      if (this.$store.state.interactiveMap.cards.length > 0) {
+        // Card have been added (user might be visualizing jobs or existing
+        // designs), so select the last card in the list.
+        this.selectedCard = this.$store.state.interactiveMap.cards[
+          this.$store.state.interactiveMap.cards.length - 1
+        ];
+      } else {
+        // Otherwise, add a default card. Chain promises to ensure that data is
+        // available.
+        this.$store.state.models.modelsPromise.then(() => {
+          this.$store.state.organisms.organismsPromise.then(() => {
+            this.addDefaultCard(false);
+          });
         });
-      });
+      }
     },
     changeMap() {
       this.hasLoadMapError = false;

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -138,7 +138,7 @@ export default Vue.extend({
     escherBuilder: null,
     currentMapId: null,
     mapData: null,
-    selectedCard: null,
+    selectedCardId: null,
     playingInterval: null,
     hasSimulationError: false,
     hasLoadMapError: false,
@@ -148,6 +148,12 @@ export default Vue.extend({
   computed: {
     cards() {
       return this.$store.state.interactiveMap.cards;
+    },
+    selectedCard() {
+      if (!this.selectedCardId) {
+        return null;
+      }
+      return this.cards.find(c => c.uuid === this.selectedCardId);
     },
     maps() {
       // Sort maps by model name, then map name
@@ -201,9 +207,9 @@ export default Vue.extend({
           this.simulate(card);
         });
         // Select the last card in the list by default.
-        this.selectedCard = this.$store.state.interactiveMap.cards[
+        this.selectedCardId = this.$store.state.interactiveMap.cards[
           this.$store.state.interactiveMap.cards.length - 1
-        ];
+        ].uuid;
       } else {
         // No cards are added at this point, so add a default card to provide
         // the user with some initial data. Chain promises to ensure that data
@@ -278,17 +284,17 @@ export default Vue.extend({
         fluxes: null
       };
       this.$store.commit("interactiveMap/addCard", card);
-      this.selectedCard = card;
+      this.selectedCardId = card.uuid;
       this.simulate(card);
     },
     removeCard(card) {
       if (card === this.selectedCard) {
         // Removing the current card - be sure to unset the reference.
-        this.selectedCard = null;
+        this.selectedCardId = null;
       }
     },
     selectCard(card) {
-      this.selectedCard = card;
+      this.selectedCardId = card.uuid;
     },
     selectPreviousCard() {
       const index = this.cards.indexOf(this.selectedCard);


### PR DESCRIPTION
In order to facilitate this, a couple extra features were necessary:
- Models are now not stored on the cards, but purely in the store
- Lazy loader action `withFullModel` in the model store lets callers guarantee that full model is available
- When adding reactions, model is now not directly modified, but a computed property based on the original model and card modifications
- Some escher sync issues are resolved

With this in place, the Designs component is now able to commit a card and redirect to the interactive map, visualizing the selected design(s).