### PR TITLE
Draw added reactions

### DIFF
--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -59,9 +59,13 @@ export interface Card {
 export default {
   namespaced: true,
   state: {
+    currentMapId: null,
     cards: [] as Card[]
   },
   mutations: {
+    setCurrentMapId(state, currentMapId) {
+      state.currentMapId = currentMapId;
+    },
     addCard(state, card) {
       state.cards.push(card);
     },

--- a/src/store/modules/models.ts
+++ b/src/store/modules/models.ts
@@ -95,6 +95,7 @@ export default {
             });
         });
         commit("setFullModelPromise", { modelId, promise });
+        return promise;
       }
     }
   },

--- a/src/views/Designs.vue
+++ b/src/views/Designs.vue
@@ -498,9 +498,9 @@ export default Vue.extend({
           .dispatch("models/withFullModel", design.model_id)
           .then(() => {
             this.$store.commit("interactiveMap/addCard", card);
+            this.$router.push({ name: "interactiveMap" });
           });
       });
-      this.$router.push({ name: "interactiveMap" });
     }
   },
   computed: {

--- a/src/views/Designs.vue
+++ b/src/views/Designs.vue
@@ -10,10 +10,19 @@
                 <v-btn
                   flat
                   color="primary"
-                  :disabled="selected.length < 1"
+                  :disabled="selected.length < 1 || isVisualizing"
                   @click="visualize"
                 >
-                  <v-icon>share</v-icon> Visualize
+                  <v-icon v-if="!isVisualizing">share</v-icon>
+                  <v-progress-circular
+                    v-else
+                    indeterminate
+                    color="primary"
+                    class="mr-1"
+                    :width="2"
+                    :size="15"
+                  ></v-progress-circular>
+                  Visualize
                 </v-btn>
                 <v-btn
                   flat
@@ -381,7 +390,10 @@ export default Vue.extend({
       { value: "reactionKnockins", align: "left" },
       { value: "reactionKnockouts", align: "left" },
       { value: "geneKnockouts", align: "left" }
-    ]
+    ],
+    // True when user clicked visualize, and we're waiting mapping and/or model
+    // to load before routing them to the interactive map.
+    isVisualizing: false
   }),
   methods: {
     customSort(items, index, isDesc) {
@@ -450,6 +462,7 @@ export default Vue.extend({
       }
     },
     visualize() {
+      this.isVisualizing = true;
       this.selected.forEach(design => {
         // TODO: Associate design id with the card
         const card = {

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -131,7 +131,6 @@ export default Vue.extend({
   data: () => ({
     isSidepanelOpen: true,
     escherBuilder: null,
-    currentMapId: null,
     mapData: null,
     selectedCardId: null,
     playingInterval: null,
@@ -140,6 +139,14 @@ export default Vue.extend({
     hasLoadDataError: false
   }),
   computed: {
+    currentMapId: {
+      get() {
+        return this.$store.state.interactiveMap.currentMapId;
+      },
+      set(currentMapId) {
+        this.$store.commit("interactiveMap/setCurrentMapId", currentMapId);
+      }
+    },
     cards() {
       return this.$store.state.interactiveMap.cards;
     },
@@ -471,16 +478,22 @@ export default Vue.extend({
     })
   },
   mounted() {
-    // Set the chosen map to the preferred default. Wait for a potential fetch
-    // request (important if the user navigates directly to this view).
-    this.$store.state.maps.mapsPromise.then(() => {
-      this.$store.state.maps.maps.forEach(map => {
-        if (map.model_id === 15 && map.name === "Core metabolism") {
-          this.currentMapId = map.id;
-          this.changeMap();
-        }
+    // Set the preferred default map.
+    if (this.currentMapId) {
+      // The user has already chosen a map - just make sure it's loaded.
+      this.changeMap();
+    } else {
+      // Wait for a potential fetch request (important if the user navigates
+      // directly to this view).
+      this.$store.state.maps.mapsPromise.then(() => {
+        this.$store.state.maps.maps.forEach(map => {
+          if (map.model_id === 15 && map.name === "Core metabolism") {
+            this.currentMapId = map.id;
+            this.changeMap();
+          }
+        });
       });
-    });
+    }
   }
 });
 </script>

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -830,9 +830,8 @@ export default Vue.extend({
                   `Method ${jobPrediction.method} is not recognized.`
                 );
               }
+              this.$router.push({ name: "interactiveMap" });
             });
-
-          this.$router.push({ name: "interactiveMap" });
         });
       });
     },

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -25,11 +25,21 @@
               <v-btn
                 flat
                 color="primary"
-                :disabled="selected.length < 1"
+                :disabled="selected.length < 1 || isVisualizing"
                 class="mt-3"
                 @click="visualize()"
-                ><v-icon>share</v-icon>VISUALIZE</v-btn
               >
+                <v-icon v-if="!isVisualizing">share</v-icon>
+                <v-progress-circular
+                  v-else
+                  indeterminate
+                  color="primary"
+                  class="mr-1"
+                  :width="2"
+                  :size="15"
+                ></v-progress-circular>
+                Visualize
+              </v-btn>
             </v-list-tile>
           </v-list>
           <v-data-table
@@ -552,7 +562,10 @@ export default Vue.extend({
       down: "↓"
     },
     showAllManipulations: false,
-    showAllKnockouts: false
+    showAllKnockouts: false,
+    // True when user clicked visualize, and we're waiting mapping and/or model
+    // to load before routing them to the interactive map.
+    isVisualizing: false
   }),
   filters: {
     round: value => {
@@ -753,6 +766,7 @@ export default Vue.extend({
       }
     },
     visualize() {
+      this.isVisualizing = true;
       const predictions = this.selected.map(jobPrediction => {
         const addedReactionIds = [
           ...jobPrediction.heterologous_reactions,


### PR DESCRIPTION
- The selected map is now saved in the store so that when you leave & go back to the interacitve map you get the same map
- Visualizing jobs now shows a little loader to show user that something is happening
- Fixed reactivity issues so that added reactions are always drawn on the map when visualizing jobs