### PR TITLE
refactor: prepend all "New" buttons

### DIFF
--- a/src/components/NewMap.vue
+++ b/src/components/NewMap.vue
@@ -4,6 +4,10 @@
       v-model="isProjectCreationDialogVisible"
       @return-object="passProject"
     />
+    <!--    <NewModel-->
+    <!--      v-model="isProjectModelDialogVisible"-->
+    <!--      @return-object="passModel"-->
+    <!--    />-->
     <v-dialog v-model="isVisible" width="650">
       <v-card class="pa-2">
         <v-container grid-list-lg text-md-left>
@@ -38,8 +42,7 @@
                   label="Project"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isProjectCreationDialogVisible = true"
@@ -47,6 +50,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New project
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete
@@ -62,6 +66,16 @@
                   label="Model"
                   type="text"
                 >
+                  <!--                  <template v-slot:prepend-item>-->
+                  <!--                    <v-btn-->
+                  <!--                      depressed-->
+                  <!--                      @click.stop="isModelCreationDialogVisible = true"-->
+                  <!--                    >-->
+                  <!--                      <v-icon class="mr-4">add_circle</v-icon>-->
+                  <!--                      New model-->
+                  <!--                    </v-btn>-->
+                  <!--                    <v-divider class="my-2"></v-divider>-->
+                  <!--                  </template>-->
                 </v-autocomplete>
                 <FileUpload
                   v-model="filename"
@@ -115,6 +129,7 @@ export default Vue.extend({
   props: ["value"],
   data: () => ({
     isProjectCreationDialogVisible: false,
+    // isModelCreationDialogVisible: false,
     filename: null,
     valid: true,
     isMapCreationSuccess: false,
@@ -173,6 +188,9 @@ export default Vue.extend({
     passProject(project) {
       this.project = project;
     }
+    // passModel(model) {
+    //   this.model = model;
+    // }
   },
   computed: {
     availableProjects() {

--- a/src/components/NewModel.vue
+++ b/src/components/NewModel.vue
@@ -48,8 +48,7 @@
                   label="Organism"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isOrganismCreationDialogVisible = true"
@@ -57,6 +56,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New Organism
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete
@@ -71,8 +71,7 @@
                   label="Project"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isProjectCreationDialogVisible = true"
@@ -80,6 +79,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New project
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete
@@ -94,8 +94,7 @@
                   label="Preferred Map"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isMapCreationDialogVisible = true"
@@ -103,6 +102,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New Map
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <FileUpload

--- a/src/components/NewOrganism.vue
+++ b/src/components/NewOrganism.vue
@@ -38,8 +38,7 @@
                   label="Project"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed=""
                       @click.stop="isProjectCreationDialogVisible = true"
@@ -47,6 +46,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New project
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
               </v-form>

--- a/src/views/Maps.vue
+++ b/src/views/Maps.vue
@@ -133,8 +133,7 @@
                   label="Project"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <!-- Work out why clicking on the project creation dialog will close it. How do I mimik the behaviour of the old platform here? -->
                     <v-btn
                       depressed
@@ -143,6 +142,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New project
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete
@@ -158,8 +158,7 @@
                   label="Model"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isModelCreationDialogVisible = true"
@@ -167,6 +166,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New Model
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
               </v-form>

--- a/src/views/Models.vue
+++ b/src/views/Models.vue
@@ -140,8 +140,7 @@
                   label="Organism"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isOrganismCreationDialogVisible = true"
@@ -149,6 +148,7 @@
                       <v-icon class="mr-4">add_circle</v-icon>
                       New organism
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete
@@ -162,15 +162,15 @@
                   label="Preferred Map"
                   type="text"
                 >
-                  <template v-slot:append-item>
-                    <v-divider class="my-2"></v-divider>
+                  <template v-slot:prepend-item>
                     <v-btn
                       depressed
                       @click.stop="isMapCreationDialogVisible = true"
                     >
                       <v-icon class="mr-4">add_circle</v-icon>
-                      New Map
+                      New map
                     </v-btn>
+                    <v-divider class="my-2"></v-divider>
                   </template>
                 </v-autocomplete>
                 <v-autocomplete


### PR DESCRIPTION
In auto-complete components we used to append the buttons for creating
new elements. With long lists the button would not be immediately
visible to users.

Some further observations:

1. Currently, we register all components globally at the moment (using `Vue.extend`). We might want to change this in future for optimization. See [the documentation on this topic](https://vuejs.org/v2/guide/components-registration.html) for more information.
2. I ran into a problem with exceeding the stack size when registering components within components. We might have to re-factor so that the components are included only once in the DOM and then opened by global store or via events.
3. This is more of a question: @phantomas1234 what about the model edit dialog on the interactive map? Should users be able to create new models, maps, experiments, etc. also directly from there?