### PR TITLE
Lint with production mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - npm ci
 
 script:
-  - npx vue-cli-service lint --no-fix --max-warnings 0
+  - npx vue-cli-service lint --mode production --no-fix --max-warnings 0
   - npx vue-cli-service test:unit
 
 deploy:


### PR DESCRIPTION
This makes sure that [lint rules that only apply for production](https://github.com/DD-DeCaF/caffeine-vue/blob/devel/.eslintrc.js#L8) causes PR builds to fail.