### PR TITLE
Report fetchError to Sentry

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -271,10 +271,10 @@ export default Vue.extend({
     },
     hasFetchDataError: {
       get() {
-        return this.$store.state.fetchDataError !== null;
+        return this.$store.state.fetchDataError;
       },
       set(newValue) {
-        this.$store.commit("setFetchError", null);
+        this.$store.commit("setFetchError", false);
       }
     },
     hasPostDataError: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 import Vue from "vue";
 import Vuex from "vuex";
+import * as Sentry from "@sentry/browser";
 import session from "./modules/session";
 import designs from "./modules/designs";
 import experiments from "./modules/experiments";
@@ -25,7 +26,7 @@ export default new Vuex.Store({
     interactiveMap
   },
   state: {
-    fetchDataError: null,
+    fetchDataError: false,
     postDataError: null,
     deleteDataError: null,
     unauthorizedError: null,
@@ -41,8 +42,8 @@ export default new Vuex.Store({
     }
   },
   mutations: {
-    setFetchError(state, error) {
-      state.fetchDataError = error;
+    setFetchError(state, hasError) {
+      state.fetchDataError = hasError;
     },
     setPostError(state, error) {
       state.postDataError = error;
@@ -66,6 +67,15 @@ export default new Vuex.Store({
       dispatch("models/fetchModels");
       dispatch("organisms/fetchOrganisms");
       dispatch("projects/fetchProjects");
+    },
+    setFetchError({ commit }, error) {
+      // Dispatch this action when failing to retrieve platform data from the
+      // backend. The root issue can vary (backend service down, invalid
+      // request, runtime error in callbacks, etc.) so this generic action will
+      // report the error to Sentry and display a generic error message to the
+      // user.
+      Sentry.captureException(error);
+      commit("setFetchError", true);
     }
   },
   strict: process.env.NODE_ENV !== "production"

--- a/src/store/modules/designs.ts
+++ b/src/store/modules/designs.ts
@@ -40,7 +40,7 @@ export default {
     }
   },
   actions: {
-    fetchDesigns({ commit }) {
+    fetchDesigns({ commit, dispatch }) {
       const designsPromise = axios
         .get(`${settings.apis.designStorage}/designs`)
         .then((response: AxiosResponse<DesignItem[]>) => {
@@ -87,7 +87,7 @@ export default {
           );
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
       commit("setDesignsPromise", designsPromise);
     }

--- a/src/store/modules/experiments.ts
+++ b/src/store/modules/experiments.ts
@@ -22,14 +22,14 @@ export default {
     }
   },
   actions: {
-    fetchExperiments({ commit }) {
+    fetchExperiments({ commit, dispatch }) {
       axios
         .get(`${settings.apis.warehouse}/experiments`)
         .then((response: AxiosResponse<ExperimentItem[]>) => {
           commit("setExperiments", response.data);
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
     }
   }

--- a/src/store/modules/jobs.ts
+++ b/src/store/modules/jobs.ts
@@ -46,7 +46,7 @@ export default {
           commit("setJobs", response.data);
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         })
         .then(() => {
           if (

--- a/src/store/modules/maps.ts
+++ b/src/store/modules/maps.ts
@@ -34,14 +34,14 @@ export default {
     }
   },
   actions: {
-    fetchMaps({ commit }) {
+    fetchMaps({ commit, dispatch }) {
       const mapsPromise = axios
         .get(`${settings.apis.maps}/maps`)
         .then((response: AxiosResponse<MapItem[]>) => {
           commit("setMaps", response.data);
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
       commit("setMapsPromise", mapsPromise);
     }

--- a/src/store/modules/models.ts
+++ b/src/store/modules/models.ts
@@ -55,7 +55,7 @@ export default {
     }
   },
   actions: {
-    fetchModels({ commit }) {
+    fetchModels({ commit, dispatch }) {
       const modelsPromise = axios
         .get(`${settings.apis.modelStorage}/models`)
         .then((response: AxiosResponse<ModelItem[]>) => {
@@ -70,11 +70,11 @@ export default {
           );
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
       commit("setModelsPromise", modelsPromise);
     },
-    withFullModel({ state, commit }, modelId) {
+    withFullModel({ state, commit, dispatch }, modelId) {
       // Use this action's returned promise to run logic which needs the full
       // model to be available. If requested for the first time it will be
       // retrieved, and from then on stay cached in the store and returned
@@ -90,7 +90,7 @@ export default {
               resolve(response.data);
             })
             .catch(error => {
-              commit("setFetchError", error, { root: true });
+              dispatch("setFetchError", error, { root: true });
               reject(error);
             });
         });

--- a/src/store/modules/organisms.ts
+++ b/src/store/modules/organisms.ts
@@ -28,14 +28,14 @@ export default {
     }
   },
   actions: {
-    fetchOrganisms({ commit }) {
+    fetchOrganisms({ commit, dispatch }) {
       const organismsPromise = axios
         .get(`${settings.apis.warehouse}/organisms`)
         .then((response: AxiosResponse<OrganismItem[]>) => {
           commit("setOrganisms", response.data);
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
       commit("setOrganismsPromise", organismsPromise);
     }

--- a/src/store/modules/projects.ts
+++ b/src/store/modules/projects.ts
@@ -64,7 +64,7 @@ export default {
     }
   },
   actions: {
-    fetchProjects({ commit }) {
+    fetchProjects({ commit, dispatch }) {
       const projectsPromise: Promise<void> = axios
         .get(`${settings.apis.iam}/projects`)
         .then((response: AxiosResponse<ProjectItem[]>) => {
@@ -81,7 +81,7 @@ export default {
           );
         })
         .catch(error => {
-          commit("setFetchError", error, { root: true });
+          dispatch("setFetchError", error, { root: true });
         });
       commit("setProjectsPromise", projectsPromise);
     }

--- a/src/views/Design.vue
+++ b/src/views/Design.vue
@@ -324,7 +324,7 @@ export default Vue.extend({
           this.productOptions = response.data;
         })
         .catch((error: Error) => {
-          this.$store.commit("setFetchError", error, { root: true });
+          this.$store.dispatch("setFetchError", error, { root: true });
         })
         .finally(() => {
           this.isLoadingProducts = false;

--- a/src/views/Jobs/JobDetails.vue
+++ b/src/views/Jobs/JobDetails.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
           this.prediction = response.data;
         })
         .catch(error => {
-          this.$store.commit("setFetchError", error);
+          this.$store.dispatch("setFetchError", error);
         });
     }
   }

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -907,7 +907,7 @@ export default Vue.extend({
             };
           })
           .catch(error => {
-            this.$store.commit("setFetchError", error);
+            this.$store.dispatch("setFetchError", error);
           });
       });
     }

--- a/tests/unit/app.spec.ts
+++ b/tests/unit/app.spec.ts
@@ -8,7 +8,7 @@ localVue.use(Vuex);
 
 const store = new Vuex.Store({
   state: {
-    fetchDataError: null,
+    fetchDataError: false,
     postDataError: null,
     deleteDataError: null,
     isDialogVisible: {


### PR DESCRIPTION
It's inconvenient that the current fetchError mutation silently hides the underlying issue. The original idea was that setting the error object in the store makes it easy to inspect the problem, but the object is not really inspectable in the Vue devtools. So you need to add debugging statements locally and reproduce the issue to get any insight into the original error.

With this change, the issue will at least be reported to Sentry in prod/staging environments.