### PR TITLE
feat: add demo mode

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -1,0 +1,15 @@
+VUE_APP_ENVIRONMENT=demo
+# Backend endpoints
+VUE_APP_API=http://localhost:4200
+VUE_APP_MODEL_API=http://localhost:8004
+VUE_APP_MODEL_STORAGE_API=http://localhost:8005
+VUE_APP_WAREHOUSE_API=http://localhost:8006
+VUE_APP_MAPS_API=http://localhost:8002
+VUE_APP_IAM_API=http://localhost:8001
+VUE_APP_METABOLIC_NINJA_API=http://localhost:8003
+VUE_APP_DESIGN_STORAGE_API=http://localhost:8007
+VUE_APP_ID_MAPPER_API=http://localhost:8008
+VUE_APP_METANETX_API=http://localhost:8009
+VUE_APP_BIGG_API=https://api.dd-decaf.eu/bigg
+# Other configuration values
+VUE_APP_TRUSTED_URLS=http://localhost

--- a/.env.demo
+++ b/.env.demo
@@ -1,6 +1,5 @@
-VUE_APP_ENVIRONMENT=demo
+VUE_APP_ENVIRONMENT=staging
 # Backend endpoints
-VUE_APP_API=http://localhost:4200
 VUE_APP_MODEL_API=http://localhost:8004
 VUE_APP_MODEL_STORAGE_API=http://localhost:8005
 VUE_APP_WAREHOUSE_API=http://localhost:8006
@@ -10,6 +9,5 @@ VUE_APP_METABOLIC_NINJA_API=http://localhost:8003
 VUE_APP_DESIGN_STORAGE_API=http://localhost:8007
 VUE_APP_ID_MAPPER_API=http://localhost:8008
 VUE_APP_METANETX_API=http://localhost:8009
-VUE_APP_BIGG_API=https://api.dd-decaf.eu/bigg
 # Other configuration values
 VUE_APP_TRUSTED_URLS=http://localhost

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,4 @@
+# Build demo image and push to dockerhub (you need to login to dockerhub first)
+npx vue-cli-service build --mode demo --dest nginx/dist
+docker build -t dddecaf/caffeine-vue-demo nginx
+docker push dddecaf/caffeine-vue-demo


### PR DESCRIPTION
A demo mode is needed to facilitate the deployment of Caffeine for evaluation purposes (see also https://github.com/dd-decaf/caffeine-bootstrap) into an environment without internet access.
Also, a script for generating a demo image of caffeine-vue and pushing it to Dockerhub has been included.