### PR TITLE
Require curly braces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,8 @@ module.exports = {
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
-    "vue/order-in-components": "error"
+    "vue/order-in-components": "error",
+    curly: "error"
   },
   parserOptions: {
     parser: "@typescript-eslint/parser"

--- a/src/views/InteractiveMap/CardDialogDesign.vue
+++ b/src/views/InteractiveMap/CardDialogDesign.vue
@@ -378,9 +378,15 @@ export default Vue.extend({
           const fullMetabolite = addReaction.mnxReaction.metabolites.find(
             ({ mnx_id }) => mnx_id === m.id
           );
-          if (!fullMetabolite) return m;
-          if (!fullMetabolite.annotation) return m;
-          if (!fullMetabolite.annotation.bigg) return m;
+          if (!fullMetabolite) {
+            return m;
+          }
+          if (!fullMetabolite.annotation) {
+            return m;
+          }
+          if (!fullMetabolite.annotation.bigg) {
+            return m;
+          }
 
           // TODO: optimize for performance
           let matchingMetaboliteInModel = null as Metabolite | null | undefined;
@@ -390,7 +396,9 @@ export default Vue.extend({
             );
             return !!matchingMetaboliteInModel;
           });
-          if (!matchingMetaboliteInModel) return m;
+          if (!matchingMetaboliteInModel) {
+            return m;
+          }
 
           // TODO: instead of removing the compartment here and adding it later,
           // we should just pass the metabolite identifiers as they are.

--- a/src/views/InteractiveMap/ReactionDialogMetabolite.vue
+++ b/src/views/InteractiveMap/ReactionDialogMetabolite.vue
@@ -130,7 +130,9 @@ export default Vue.extend({
       }
     },
     onMetaboliteChange(metabolite, value) {
-      if (!value) return;
+      if (!value) {
+        return;
+      }
       if (value.compartment) {
         metabolite.compartment = value.compartment;
       } else {


### PR DESCRIPTION
This is a suggestion to add the [`curly`](https://eslint.org/docs/rules/curly) eslint rule to require curly braces for code clarity. For example, the following:

```
if (foo) foo++;
```

Must be rewritten as:

```
if (foo) {
    foo++;
}
```