### PR TITLE
fix: undo reaction knockout

### DIFF
--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -123,11 +123,11 @@ export default {
     },
     undoKnockoutReaction(state, { uuid, reactionId }) {
       const card = state.cards.find(c => c.uuid === uuid);
-      card.reactionKnockouts.splice(
-        card.reactionKnockouts.findIndex(k => k.id === reactionId),
-        1
-      );
-      card.modified = true;
+      const index = card.reactionKnockouts.findIndex(k => k.id === reactionId);
+      if (index !== -1) {
+        card.reactionKnockouts.splice(index, 1);
+        card.modified = true;
+      }
     },
     knockoutGene(state, { uuid, gene }) {
       const card = state.cards.find(c => c.uuid === uuid);

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -175,8 +175,10 @@ export default {
     undoEditBounds(state, { uuid, reactionId }) {
       const card = state.cards.find(c => c.uuid === uuid);
       const index = card.editedBounds.findIndex(r => r.id === reactionId);
-      card.editedBounds.splice(index, 1);
-      card.modified = true;
+      if (index !== -1) {
+        card.editedBounds.splice(index, 1);
+        card.modified = true;
+      }
     }
   },
   actions: {

--- a/src/views/InteractiveMap/CardDialogDesign.vue
+++ b/src/views/InteractiveMap/CardDialogDesign.vue
@@ -491,10 +491,15 @@ export default Vue.extend({
           reactionId: modification.id
         });
         // If the objective was set to the added reaction, clear it.
-        this.$store.commit("interactiveMap/setObjectiveReaction", {
-          uuid: this.card.uuid,
-          reaction: null
-        });
+        if (
+          this.card.objective.reaction &&
+          this.card.objective.reaction.id === modification.id
+        ) {
+          this.$store.commit("interactiveMap/setObjectiveReaction", {
+            uuid: this.card.uuid,
+            reaction: null
+          });
+        }
         // Adding and then knocking out the same reaction makes little sense,
         // but is technically possible, so remove the knockouts too if that's
         // the case.


### PR DESCRIPTION
While deleting added reaction modification, we are checking if that reaction was knocked out before to delete also that knockout. Previously the last reaction knockout was removed regardless of id.