### PR TITLE
fix: added missing item-value to dropdowns with return-object

### DIFF
--- a/src/components/NewModel.vue
+++ b/src/components/NewModel.vue
@@ -40,7 +40,7 @@
                   required
                   return-object
                   item-text="name"
-                  item-id="id"
+                  item-value="id"
                   v-model="organism"
                   :items="availableOrganisms"
                   :rules="[rules.required]"
@@ -63,7 +63,7 @@
                   required
                   return-object
                   item-text="name"
-                  item-id="id"
+                  item-value="id"
                   v-model="project"
                   :items="availableProjects"
                   :rules="[rules.required]"
@@ -85,7 +85,7 @@
                 <v-autocomplete
                   return-object
                   item-text="name"
-                  item-id="id"
+                  item-value="id"
                   v-model="map"
                   :items="availableMaps"
                   hint="The default map displayed on the Interactive Map, optional"
@@ -117,6 +117,7 @@
                 <v-autocomplete
                   required
                   item-text="id"
+                  item-value="id"
                   v-model="default_biomass_reaction"
                   :items="reactions"
                   :rules="[rules.required]"

--- a/src/components/NewOrganism.vue
+++ b/src/components/NewOrganism.vue
@@ -30,6 +30,7 @@
                 <v-autocomplete
                   return-object
                   required
+                  item-value="id"
                   item-text="name"
                   v-model="project"
                   :items="availableProjects"

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -7,6 +7,7 @@
         :items="experiments"
         v-model="cardExperiment"
         item-text="name"
+        item-value="id"
         placeholder="Choose the experiment you wish to simulate..."
         return-object
       ></v-autocomplete>
@@ -19,6 +20,7 @@
         :loading="isLoadingConditions"
         :disabled="conditions === []"
         item-text="name"
+        item-value="id"
         placeholder="Choose the conditions you wish to simulate"
         return-object
       ></v-autocomplete>

--- a/src/views/Models.vue
+++ b/src/views/Models.vue
@@ -176,6 +176,7 @@
                 <v-autocomplete
                   required
                   item-text="id"
+                  item-value="id"
                   v-model="default_biomass_reaction"
                   :items="reactions"
                   hint="The reaction identifier of this model's default biomass reaction"


### PR DESCRIPTION
Example
- [Before](https://user-images.githubusercontent.com/3758846/60796620-07274780-a16e-11e9-8a41-bb9e994ed226.gif)
- [After](https://user-images.githubusercontent.com/3758846/60797727-23c47f00-a170-11e9-83b5-71c2025b8d2a.gif)
- data driven card returns conditions with same names (A1) for different experiments
- when using `return-object` without `item-value`, items will be compared by displayed text https://github.com/vuetifyjs/vuetify/issues/7775
