### PR TITLE
fix: visualize cofactor swap results by passing stoichiometry to Escher

### DIFF
--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -1031,10 +1031,11 @@ export default Vue.extend({
                 // metabolites should be array of objects
                 const metabolites = Object.keys(reactionToAdd.metabolites).map(
                   metaboliteId => ({
-                    id: metaboliteId,
                     // compartment is always "c" for now
                     // should be reconsidered later
-                    compartment: "c"
+                    id: getMetaboliteId(metaboliteId, "c"),
+                    compartment: "c",
+                    stoichiometry: reactionToAdd.metabolites[metaboliteId]
                   })
                 );
                 const substratesSerialized = substrates.join(" + ");
@@ -1060,10 +1061,7 @@ export default Vue.extend({
                   lowerBound: lowerBound,
                   upperBound: upperBound,
                   reactionString: reactionString,
-                  metabolites: metabolites.map(metabolite => ({
-                    ...metabolite,
-                    id: getMetaboliteId(metabolite.id, metabolite.compartment)
-                  }))
+                  metabolites: metabolites
                 });
               });
               knockoutIds.forEach(reactionId => {


### PR DESCRIPTION
Without stoichiometry, it defaults to NaN and puts all metabolites on
one side (all products, because NaN < 0 is false)

| Before | After |
| --- | --- |
| ![b](https://user-images.githubusercontent.com/3758846/60967301-a0935c80-a31a-11e9-82c2-aa4508b9ed38.png) | ![a](https://user-images.githubusercontent.com/3758846/60967299-9f622f80-a31a-11e9-9537-33b594dcbbcc.png) |


