### PR TITLE
Frontend fva

### DIFF
--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -153,6 +153,12 @@ export default {
       card.editedBounds.push(reaction);
       card.modified = true;
     },
+    editMultipleBounds(state, { uuid, reactions }) {
+      // Add multiple reaction objects with modified bounds.
+      const card = state.cards.find(c => c.uuid === uuid);
+      card.editedBounds.push(...reactions);
+      card.modified = true;
+    },
     updateEditedBoundsReaction(state, { uuid, reaction }) {
       // Update the reaction data for an edited reaction.
       const card = state.cards.find(c => c.uuid === uuid);

--- a/src/views/InteractiveMap/CardDialogDiffFVA.vue
+++ b/src/views/InteractiveMap/CardDialogDiffFVA.vue
@@ -31,6 +31,21 @@
           </v-list>
         </v-card>
       </v-flex>
+      <v-flex>
+        <v-card class="mx-2">
+          <v-subheader>Flux Inversion targets</v-subheader>
+          <v-list
+            v-for="manipulation in inversionTargets"
+            :key="manipulation.id"
+          >
+            <v-list-tile>
+              <v-list-tile-content>
+                <v-list-tile-title> {{ manipulation.id }} ⇅ </v-list-tile-title>
+              </v-list-tile-content>
+            </v-list-tile>
+          </v-list>
+        </v-card>
+      </v-flex>
     </v-layout>
   </div>
 </template>
@@ -53,6 +68,11 @@ export default Vue.extend({
     knockdownTargets() {
       return [...this.card.manipulations].filter(
         manipulation => manipulation.direction === "down"
+      );
+    },
+    inversionTargets() {
+      return [...this.card.manipulations].filter(
+        manipulation => manipulation.direction === "invert"
       );
     }
   },

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -128,7 +128,7 @@ export default Vue.extend({
       if (this.card.type === "DiffFVA") {
         let scores = {};
         this.card.manipulations.forEach(manipulation => {
-          scores[manipulation.id] = manipulation.value;
+          scores[manipulation.id] = manipulation.score;
         });
         return scores;
       } else {

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -292,7 +292,6 @@ export default Vue.extend({
       );
     },
     setFluxes() {
-      console.log("setFluxes")
       // Update the flux distribution
       if (this.card === null || this.card.fluxes === null) {
         this.escherBuilder.set_reaction_data(null);
@@ -302,7 +301,6 @@ export default Vue.extend({
           !this.showDiffFVAScore
         ) {
           const fluxesFiltered = this.fluxFilter(this.card.fluxes);
-          console.log("Back in setFluxes")
           this.escherBuilder.set_reaction_data(fluxesFiltered);
           // Set FVA data with the current fluxes. This resets opacity in case a
           // previous FVA simulation has been set on the map.
@@ -335,7 +333,6 @@ export default Vue.extend({
       this.escherBuilder._updateData(true, true);
     },
     fluxFilter(fluxes) {
-      console.log("fluxFilter")
       // Exclude fluxes with very low non-zero values, in order to not shift
       // the escher color scale.
       // Note that this is a method, not a computed property from the card
@@ -347,7 +344,6 @@ export default Vue.extend({
           fluxesFiltered[rxn] = fluxes[rxn];
         }
       });
-      console.log(fluxesFiltered)
       return fluxesFiltered;
     },
     getObjectState(id: string, type: string) {
@@ -512,7 +508,6 @@ export default Vue.extend({
       this.$emit("simulate-card", this.card, this.model);
     },
     toggleColorScheme() {
-      console.log("toggleColorScheme")
       if (this.card.showDiffFVAScore) {
         this.escherBuilder.settings.set("reaction_scale", [
           { type: "min", color: "#a841d0", size: 20 },
@@ -531,7 +526,7 @@ export default Vue.extend({
         );
         this.escherBuilder.settings.set(
           "reaction_styles",
-          this.defaultReactionStyle
+          this.defaultReactionStyles
         );
       }
     }

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -292,6 +292,7 @@ export default Vue.extend({
       );
     },
     setFluxes() {
+      console.log("setFluxes")
       // Update the flux distribution
       if (this.card === null || this.card.fluxes === null) {
         this.escherBuilder.set_reaction_data(null);
@@ -301,6 +302,7 @@ export default Vue.extend({
           !this.showDiffFVAScore
         ) {
           const fluxesFiltered = this.fluxFilter(this.card.fluxes);
+          console.log("Back in setFluxes")
           this.escherBuilder.set_reaction_data(fluxesFiltered);
           // Set FVA data with the current fluxes. This resets opacity in case a
           // previous FVA simulation has been set on the map.
@@ -333,6 +335,7 @@ export default Vue.extend({
       this.escherBuilder._updateData(true, true);
     },
     fluxFilter(fluxes) {
+      console.log("fluxFilter")
       // Exclude fluxes with very low non-zero values, in order to not shift
       // the escher color scale.
       // Note that this is a method, not a computed property from the card
@@ -344,6 +347,7 @@ export default Vue.extend({
           fluxesFiltered[rxn] = fluxes[rxn];
         }
       });
+      console.log(fluxesFiltered)
       return fluxesFiltered;
     },
     getObjectState(id: string, type: string) {
@@ -508,6 +512,7 @@ export default Vue.extend({
       this.$emit("simulate-card", this.card, this.model);
     },
     toggleColorScheme() {
+      console.log("toggleColorScheme")
       if (this.card.showDiffFVAScore) {
         this.escherBuilder.settings.set("reaction_scale", [
           { type: "min", color: "#a841d0", size: 20 },

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -458,14 +458,15 @@ export default Vue.extend({
         }
       });
       // Apply the values from diffFVA results as bounds for simulation
-      const editedBounds = card.manipulations
-        .map(function(manipulation) {
-          // do we need to filter out values that are zero or is this controlled on the backend?
-          const model_reaction =  model.model_serialized.reactions.find(rxn => rxn.id === manipulation.id)
-          const newBound = manipulation.value;
-          switch (manipulation.direction) {
-            case 'up':
-              if (newBound > 0) {
+      const editedBounds = card.manipulations.map(function(manipulation) {
+        // do we need to filter out values that are zero or is this controlled on the backend?
+        const model_reaction = model.model_serialized.reactions.find(
+          rxn => rxn.id === manipulation.id
+        );
+        const newBound = manipulation.value;
+        switch (manipulation.direction) {
+          case "up":
+            if (newBound > 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -475,8 +476,8 @@ export default Vue.extend({
                   upper_bound: model_reaction.upper_bound
                 }
               };
-              };
-              if (newBound < 0) {
+            }
+            if (newBound < 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -486,10 +487,10 @@ export default Vue.extend({
                   lower_bound: model_reaction.lower_bound
                 }
               };
-              };
-              break;
-              case 'down':
-              if (newBound > 0) {
+            }
+            break;
+          case "down":
+            if (newBound > 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -499,8 +500,8 @@ export default Vue.extend({
                   lower_bound: model_reaction.lower_bound
                 }
               };
-              };
-              if (newBound < 0) {
+            }
+            if (newBound < 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -510,10 +511,10 @@ export default Vue.extend({
                   upper_bound: model_reaction.upper_bound
                 }
               };
-              };
-              break;
-              case 'invert':
-              if (newBound > 0) {
+            }
+            break;
+          case "invert":
+            if (newBound > 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -523,8 +524,8 @@ export default Vue.extend({
                   upper_bound: model_reaction.upper_bound
                 }
               };
-              };
-              if (newBound < 0) {
+            }
+            if (newBound < 0) {
               return {
                 operation: "modify",
                 type: "reaction",
@@ -534,17 +535,17 @@ export default Vue.extend({
                   lower_bound: model_reaction.lower_bound
                 }
               };
-              };
-              break;
-          }
-            })
-          // Simulate the model with the updated bounds
-          // adding first all the modifications from the design
-          // and then the modifications (edited bounds) computed above
-          this.postSimulation(card, model, [
-            ...this.cardModifications(card),
-            ...editedBounds
-          ]);
+            }
+            break;
+        }
+      });
+      // Simulate the model with the updated bounds
+      // adding first all the modifications from the design
+      // and then the modifications (edited bounds) computed above
+      this.postSimulation(card, model, [
+        ...this.cardModifications(card),
+        ...editedBounds
+      ]);
     },
     postSimulation(card, model, operations) {
       this.updateCard({

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -459,13 +459,57 @@ export default Vue.extend({
       });
       // Apply the values from diffFVA results as bounds for simulation
       const editedBounds = card.manipulations.map(function(manipulation) {
-        // do we need to filter out values that are zero or is this controlled on the backend?
         const model_reaction = model.model_serialized.reactions.find(
           rxn => rxn.id === manipulation.id
         );
+        // manipulation.value can never be equal to zero hence we don't need to check for it.
         const newBound = manipulation.value;
-        switch (manipulation.direction) {
-          case "up":
+        if (manipulation.direction === "up") {
+            if (newBound > 0) {
+              return {
+                operation: "modify",
+                type: "reaction",
+                id: manipulation.id,
+                data: {
+                  lower_bound: newBound,
+                  upper_bound: model_reaction.upper_bound
+                }
+              };
+            }
+            if (newBound < 0) {
+              return {
+                operation: "modify",
+                type: "reaction",
+                id: manipulation.id,
+                data: {
+                  upper_bound: newBound,
+                  lower_bound: model_reaction.lower_bound
+                }
+              };
+            }} else if (manipulation.direction === "down") {
+            if (newBound > 0) {
+              return {
+                operation: "modify",
+                type: "reaction",
+                id: manipulation.id,
+                data: {
+                  upper_bound: newBound,
+                  lower_bound: model_reaction.lower_bound
+                }
+              };
+            }
+            if (newBound < 0) {
+              return {
+                operation: "modify",
+                type: "reaction",
+                id: manipulation.id,
+                data: {
+                  lower_bound: newBound,
+                  upper_bound: model_reaction.upper_bound
+                }
+              };
+            }
+            } else if (manipulation.direction === "invert") {
             if (newBound > 0) {
               return {
                 operation: "modify",
@@ -488,55 +532,7 @@ export default Vue.extend({
                 }
               };
             }
-            break;
-          case "down":
-            if (newBound > 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  upper_bound: newBound,
-                  lower_bound: model_reaction.lower_bound
-                }
-              };
             }
-            if (newBound < 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  lower_bound: newBound,
-                  upper_bound: model_reaction.upper_bound
-                }
-              };
-            }
-            break;
-          case "invert":
-            if (newBound > 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  lower_bound: newBound,
-                  upper_bound: model_reaction.upper_bound
-                }
-              };
-            }
-            if (newBound < 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  upper_bound: newBound,
-                  lower_bound: model_reaction.lower_bound
-                }
-              };
-            }
-            break;
         }
       });
       // Simulate the model with the updated bounds

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -449,7 +449,6 @@ export default Vue.extend({
         });
     },
     simulateDiffFVACard(card, model) {
-      const operations = this.cardModifications(card);
       this.updateCard({
         uuid: card.uuid,
         props: {
@@ -465,76 +464,76 @@ export default Vue.extend({
         // manipulation.value can never be equal to zero hence we don't need to check for it.
         const newBound = manipulation.value;
         if (manipulation.direction === "up") {
-            if (newBound > 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  lower_bound: newBound,
-                  upper_bound: model_reaction.upper_bound
-                }
-              };
-            }
-            if (newBound < 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  upper_bound: newBound,
-                  lower_bound: model_reaction.lower_bound
-                }
-              };
-            }} else if (manipulation.direction === "down") {
-            if (newBound > 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  upper_bound: newBound,
-                  lower_bound: model_reaction.lower_bound
-                }
-              };
-            }
-            if (newBound < 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  lower_bound: newBound,
-                  upper_bound: model_reaction.upper_bound
-                }
-              };
-            }
-            } else if (manipulation.direction === "invert") {
-            if (newBound > 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  lower_bound: newBound,
-                  upper_bound: model_reaction.upper_bound
-                }
-              };
-            }
-            if (newBound < 0) {
-              return {
-                operation: "modify",
-                type: "reaction",
-                id: manipulation.id,
-                data: {
-                  upper_bound: newBound,
-                  lower_bound: model_reaction.lower_bound
-                }
-              };
-            }
-            }
+          if (newBound > 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                lower_bound: newBound,
+                upper_bound: model_reaction.upper_bound
+              }
+            };
+          }
+          if (newBound < 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                upper_bound: newBound,
+                lower_bound: model_reaction.lower_bound
+              }
+            };
+          }
+        } else if (manipulation.direction === "down") {
+          if (newBound > 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                upper_bound: newBound,
+                lower_bound: model_reaction.lower_bound
+              }
+            };
+          }
+          if (newBound < 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                lower_bound: newBound,
+                upper_bound: model_reaction.upper_bound
+              }
+            };
+          }
+        } else if (manipulation.direction === "invert") {
+          if (newBound > 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                lower_bound: newBound,
+                upper_bound: model_reaction.upper_bound
+              }
+            };
+          }
+          if (newBound < 0) {
+            return {
+              operation: "modify",
+              type: "reaction",
+              id: manipulation.id,
+              data: {
+                upper_bound: newBound,
+                lower_bound: model_reaction.lower_bound
+              }
+            };
+          }
         }
-      );
+      });
       // Simulate the model with the updated bounds
       // adding first all the modifications from the design
       // and then the modifications (edited bounds) computed above

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -458,82 +458,47 @@ export default Vue.extend({
       });
       // Apply the values from diffFVA results as bounds for simulation
       const editedBounds = card.manipulations.map(manipulation => {
-        const model_reaction = model.model_serialized.reactions.find(
-          rxn => rxn.id === manipulation.id
-        );
-        // manipulation.value can never be equal to zero hence we don't need to check for it.
-        const newBound = manipulation.value;
-        if (manipulation.direction === "up") {
-          if (newBound > 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                lower_bound: newBound,
-                upper_bound: model_reaction.upper_bound
-              }
-            };
-          }
-          if (newBound < 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                upper_bound: newBound,
-                lower_bound: model_reaction.lower_bound
-              }
-            };
-          }
-        } else if (manipulation.direction === "down") {
-          if (newBound > 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                upper_bound: newBound,
-                lower_bound: model_reaction.lower_bound
-              }
-            };
-          }
-          if (newBound < 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                lower_bound: newBound,
-                upper_bound: model_reaction.upper_bound
-              }
-            };
-          }
-        } else if (manipulation.direction === "invert") {
-          if (newBound > 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                lower_bound: newBound,
-                upper_bound: model_reaction.upper_bound
-              }
-            };
-          }
-          if (newBound < 0) {
-            return {
-              operation: "modify",
-              type: "reaction",
-              id: manipulation.id,
-              data: {
-                upper_bound: newBound,
-                lower_bound: model_reaction.lower_bound
-              }
-            };
-          }
-        }
-      });
+  const model_reaction = model.model_serialized.reactions.find(
+    rxn => rxn.id === manipulation.id
+  );
+  const oldLowerBound = model_reaction.lower_bound;
+  const oldUpperBound = model_reaction.upper_bound;
+
+  // manipulation.value can never be equal to zero hence we don't need to check for it.
+  const newBound = manipulation.value;
+
+  if (
+    (manipulation.direction === "up" && newBound > 0) ||
+    (manipulation.direction === "invert" && newBound > 0) ||
+    (manipulation.direction === "down" && newBound < 0)
+  ) {
+    return {
+      operation: "modify",
+      type: "reaction",
+      id: manipulation.id,
+      data: {
+        lower_bound: newBound,
+        upper_bound: oldUpperBound
+      }
+    };
+  }
+
+  if (
+    (manipulation.direction === "up" && newBound < 0) ||
+    (manipulation.direction === "invert" && newBound < 0) ||
+    (manipulation.direction === "down" && newBound > 0)
+  ) {
+    return {
+      operation: "modify",
+      type: "reaction",
+      id: manipulation.id,
+      data: {
+        lower_bound: oldLowerBound,
+        upper_bound: newBound
+      }
+    };
+  }
+});
       // Simulate the model with the updated bounds
       // adding first all the modifications from the design
       // and then the modifications (edited bounds) computed above

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -458,47 +458,47 @@ export default Vue.extend({
       });
       // Apply the values from diffFVA results as bounds for simulation
       const editedBounds = card.manipulations.map(manipulation => {
-  const model_reaction = model.model_serialized.reactions.find(
-    rxn => rxn.id === manipulation.id
-  );
-  const oldLowerBound = model_reaction.lower_bound;
-  const oldUpperBound = model_reaction.upper_bound;
+        const model_reaction = model.model_serialized.reactions.find(
+          rxn => rxn.id === manipulation.id
+        );
+        const oldLowerBound = model_reaction.lower_bound;
+        const oldUpperBound = model_reaction.upper_bound;
 
-  // manipulation.value can never be equal to zero hence we don't need to check for it.
-  const newBound = manipulation.value;
+        // manipulation.value can never be equal to zero hence we don't need to check for it.
+        const newBound = manipulation.value;
 
-  if (
-    (manipulation.direction === "up" && newBound > 0) ||
-    (manipulation.direction === "invert" && newBound > 0) ||
-    (manipulation.direction === "down" && newBound < 0)
-  ) {
-    return {
-      operation: "modify",
-      type: "reaction",
-      id: manipulation.id,
-      data: {
-        lower_bound: newBound,
-        upper_bound: oldUpperBound
-      }
-    };
-  }
+        if (
+          (manipulation.direction === "up" && newBound > 0) ||
+          (manipulation.direction === "invert" && newBound > 0) ||
+          (manipulation.direction === "down" && newBound < 0)
+        ) {
+          return {
+            operation: "modify",
+            type: "reaction",
+            id: manipulation.id,
+            data: {
+              lower_bound: newBound,
+              upper_bound: oldUpperBound
+            }
+          };
+        }
 
-  if (
-    (manipulation.direction === "up" && newBound < 0) ||
-    (manipulation.direction === "invert" && newBound < 0) ||
-    (manipulation.direction === "down" && newBound > 0)
-  ) {
-    return {
-      operation: "modify",
-      type: "reaction",
-      id: manipulation.id,
-      data: {
-        lower_bound: oldLowerBound,
-        upper_bound: newBound
-      }
-    };
-  }
-});
+        if (
+          (manipulation.direction === "up" && newBound < 0) ||
+          (manipulation.direction === "invert" && newBound < 0) ||
+          (manipulation.direction === "down" && newBound > 0)
+        ) {
+          return {
+            operation: "modify",
+            type: "reaction",
+            id: manipulation.id,
+            data: {
+              lower_bound: oldLowerBound,
+              upper_bound: newBound
+            }
+          };
+        }
+      });
       // Simulate the model with the updated bounds
       // adding first all the modifications from the design
       // and then the modifications (edited bounds) computed above

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -458,7 +458,7 @@ export default Vue.extend({
         }
       });
       // Apply the values from diffFVA results as bounds for simulation
-      const editedBounds = card.manipulations.map(function(manipulation) {
+      const editedBounds = card.manipulations.map(manipulation => {
         const model_reaction = model.model_serialized.reactions.find(
           rxn => rxn.id === manipulation.id
         );
@@ -534,7 +534,7 @@ export default Vue.extend({
             }
             }
         }
-      });
+      );
       // Simulate the model with the updated bounds
       // adding first all the modifications from the design
       // and then the modifications (edited bounds) computed above

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -477,7 +477,8 @@
                         "
                       >
                         <span class="caption grey--text"
-                          >↑ up-regulation<br />↓ down-regulation</span
+                          >↑ up-regulation<br />↓ down-regulation<br />⇅
+                          inversion</span
                         >
                       </div>
                     </div>
@@ -672,7 +673,8 @@ export default Vue.extend({
     indicators: {
       delta: "Δ",
       up: "↑",
-      down: "↓"
+      down: "↓",
+      invert: "⇅"
     },
     showAllManipulations: false,
     showAllKnockouts: false,

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -1003,11 +1003,32 @@ export default Vue.extend({
                 manipulation => {
                   // First find the original bounds for the reaction, because one of them
                   // will need to be part of the request to modify bounds.
-                  const model_reaction = this.model.model_serialized.reactions.find(
+                  let oldLowerBound;
+                  let oldUpperBound;
+                  // Try to find the reaction among the card's added reactions, in case
+                  // it's a heterologous one.
+                  const reactionFromCard = card.reactionAdditions.find(
                     rxn => rxn.id === manipulation.id
                   );
-                  const oldLowerBound = model_reaction.lower_bound;
-                  const oldUpperBound = model_reaction.upper_bound;
+                  if (reactionFromCard) {
+                    oldLowerBound = reactionFromCard.lowerBound;
+                    oldUpperBound = reactionFromCard.upperBound;
+                  } else {
+                    // Not one of the added reactions - look in the model.
+                    const reactionFromModel = this.model.model_serialized.reactions.find(
+                      rxn => rxn.id === manipulation.id
+                    );
+                    if (reactionFromModel) {
+                      oldLowerBound = reactionFromModel.lower_bound;
+                      oldUpperBound = reactionFromModel.upper_bound;
+                    } else {
+                      throw new Error(
+                        `Reaction ${
+                          manipulation.id
+                        } is neither added or in the original model`
+                      );
+                    }
+                  }
 
                   // manipulation.value can never be equal to zero hence we don't need to check for it.
                   const newBound = manipulation.value;


### PR DESCRIPTION
Removes obsolete logic associated with previous diffFVA response from the backend. 

The new response now looks like this:
```
{
  id: string;
  score: number;
  value: number;
  direction: ["up", "down", "invert"];
}
```
The new logic now simply constrains the model with the 'value' parameters from diffFVA and runs a simulation once:

```
direction === "up"

& value > 0
--> reaction.lower_bound = value

& value < 0
--> reaction.upper_bound = value
```

```
direction === "down"

& value > 0
--> reaction.upper_bound = value

& value < 0
--> reaction.lower_bound = value
```

```
direction === "invert"

& value > 0
--> reaction.lower_bound = value

& value < 0
--> reaction.upper_bound = value
``` 

The 'score' parameter is now displayed when toggled on the card.

