### PR TITLE
Apply DiffFVA modifications correctly

### DIFF
--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -153,6 +153,12 @@ export default {
       card.editedBounds.push(reaction);
       card.modified = true;
     },
+    editMultipleBounds(state, { uuid, reactions }) {
+      // Add multiple reaction objects with modified bounds.
+      const card = state.cards.find(c => c.uuid === uuid);
+      card.editedBounds.push(...reactions);
+      card.modified = true;
+    },
     updateEditedBoundsReaction(state, { uuid, reaction }) {
       // Update the reaction data for an edited reaction.
       const card = state.cards.find(c => c.uuid === uuid);

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -1003,11 +1003,32 @@ export default Vue.extend({
                 manipulation => {
                   // First find the original bounds for the reaction, because one of them
                   // will need to be part of the request to modify bounds.
-                  const model_reaction = this.model.model_serialized.reactions.find(
+                  let oldLowerBound;
+                  let oldUpperBound;
+                  // Try to find the reaction among the card's added reactions, in case
+                  // it's a heterologous one.
+                  const reactionFromCard = card.reactionAdditions.find(
                     rxn => rxn.id === manipulation.id
                   );
-                  const oldLowerBound = model_reaction.lower_bound;
-                  const oldUpperBound = model_reaction.upper_bound;
+                  if (reactionFromCard) {
+                    oldLowerBound = reactionFromCard.lowerBound;
+                    oldUpperBound = reactionFromCard.upperBound;
+                  } else {
+                    // Not one of the added reactions - look in the model.
+                    const reactionFromModel = this.model.model_serialized.reactions.find(
+                      rxn => rxn.id === manipulation.id
+                    );
+                    if (reactionFromModel) {
+                      oldLowerBound = reactionFromModel.lower_bound;
+                      oldUpperBound = reactionFromModel.upper_bound;
+                    } else {
+                      throw new Error(
+                        `Reaction ${
+                          manipulation.id
+                        } is neither added or in the original model`
+                      );
+                    }
+                  }
 
                   // manipulation.value can never be equal to zero hence we don't need to check for it.
                   const newBound = manipulation.value;


### PR DESCRIPTION
- Moves the DiffFVA logic from the simulation step back to being resolved when creating the card, and sets the modifications on the actual card.
- Now there's no need for the `simulateDiffFVA` function in the interactive map component, so reuse the simulation logic for a design card. (We should do the same for data driven cards actually.)
- Fix: When finding the original bounds for the manipulations, search also in the card's added reactions (so that the heterologous reactions can be found).