### PR TITLE
Recreate escher when changing maps to preserve state

### DIFF
--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -45,6 +45,7 @@ export default Vue.extend({
   props: ["mapData", "card", "isLoadingMap"],
   data: () => ({
     escherBuilder: null,
+    escherReady: false,
     initializingEscher: false,
     hasBoundsError: false,
     defaultReactionStyles: ["color", "size", "text", "abs"],
@@ -175,6 +176,7 @@ export default Vue.extend({
           zoom_extent_canvas: true,
           first_load_callback: () => {
             this.initializingEscher = false;
+            this.escherReady = true;
 
             // Update the current map state.
             // Important: Any new logic to set map state that is added below, needs to
@@ -208,7 +210,7 @@ export default Vue.extend({
         // Whenever the model (with local modifications) changes, update it in
         // Escher. Note: The model must be loaded before drawing the reactions
         // on the map.
-        if (!this.escherBuilder) {
+        if (!this.escherReady) {
           // Escher builder is not available if map data hasn't arrived yet. Ignore the
           // watcher; the state will be set explicitly when map data arrives.
           return;
@@ -230,7 +232,7 @@ export default Vue.extend({
     // of a single deep watcher on the card, to be able to only update the
     // relevant portions of the map.
     "card.reactionKnockouts"() {
-      if (!this.escherBuilder) {
+      if (!this.escherReady) {
         // Escher builder is not available if map data hasn't arrived yet. Ignore the
         // watcher; the state will be set explicitly when map data arrives.
         return;
@@ -238,7 +240,7 @@ export default Vue.extend({
       this.setReactionKnockouts();
     },
     "card.geneKnockouts"() {
-      if (!this.escherBuilder) {
+      if (!this.escherReady) {
         // Escher builder is not available if map data hasn't arrived yet. Ignore the
         // watcher; the state will be set explicitly when map data arrives.
         return;
@@ -246,7 +248,7 @@ export default Vue.extend({
       this.setGeneKnockouts();
     },
     "card.conditionData"() {
-      if (!this.escherBuilder) {
+      if (!this.escherReady) {
         // Escher builder is not available if map data hasn't arrived yet. Ignore the
         // watcher; the state will be set explicitly when map data arrives.
         return;
@@ -254,7 +256,7 @@ export default Vue.extend({
       this.setConditionData();
     },
     "card.fluxes"() {
-      if (!this.escherBuilder) {
+      if (!this.escherReady) {
         // Escher builder is not available if map data hasn't arrived yet. Ignore the
         // watcher; the state will be set explicitly when map data arrives.
         return;
@@ -262,7 +264,7 @@ export default Vue.extend({
       this.setFluxes();
     },
     showDiffFVAScore() {
-      if (!this.escherBuilder) {
+      if (!this.escherReady) {
         // Escher builder is not available if map data hasn't arrived yet. Ignore the
         // watcher; the state will be set explicitly when map data arrives.
         return;

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -45,6 +45,9 @@ export default Vue.extend({
   props: ["mapData", "card", "isLoadingMap"],
   data: () => ({
     escherBuilder: null,
+    // The following flag will be false until Escher is ready. In that period,
+    // watchers that apply state to Escher should be ignored since the builder
+    // isn't ready. The state will be set explicitly when Escher is ready.
     escherReady: false,
     initializingEscher: false,
     hasBoundsError: false,
@@ -211,8 +214,6 @@ export default Vue.extend({
         // Escher. Note: The model must be loaded before drawing the reactions
         // on the map.
         if (!this.escherReady) {
-          // Escher builder is not available if map data hasn't arrived yet. Ignore the
-          // watcher; the state will be set explicitly when map data arrives.
           return;
         }
         this.setModel();
@@ -233,40 +234,30 @@ export default Vue.extend({
     // relevant portions of the map.
     "card.reactionKnockouts"() {
       if (!this.escherReady) {
-        // Escher builder is not available if map data hasn't arrived yet. Ignore the
-        // watcher; the state will be set explicitly when map data arrives.
         return;
       }
       this.setReactionKnockouts();
     },
     "card.geneKnockouts"() {
       if (!this.escherReady) {
-        // Escher builder is not available if map data hasn't arrived yet. Ignore the
-        // watcher; the state will be set explicitly when map data arrives.
         return;
       }
       this.setGeneKnockouts();
     },
     "card.conditionData"() {
       if (!this.escherReady) {
-        // Escher builder is not available if map data hasn't arrived yet. Ignore the
-        // watcher; the state will be set explicitly when map data arrives.
         return;
       }
       this.setConditionData();
     },
     "card.fluxes"() {
       if (!this.escherReady) {
-        // Escher builder is not available if map data hasn't arrived yet. Ignore the
-        // watcher; the state will be set explicitly when map data arrives.
         return;
       }
       this.setFluxes();
     },
     showDiffFVAScore() {
       if (!this.escherReady) {
-        // Escher builder is not available if map data hasn't arrived yet. Ignore the
-        // watcher; the state will be set explicitly when map data arrives.
         return;
       }
       this.setColorScheme();

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -163,7 +163,7 @@ export default Vue.extend({
           this.setGeneKnockouts();
           this.setConditionData();
           this.setFluxes();
-          this.toggleColorScheme();
+          this.setColorScheme();
         }, 10);
       };
 
@@ -204,7 +204,7 @@ export default Vue.extend({
       this.onEscherReady.then(this.setFluxes);
     },
     showDiffFVAScore() {
-      this.onEscherReady.then(this.toggleColorScheme());
+      this.onEscherReady.then(this.setColorScheme());
       this.onEscherReady.then(this.setFluxes);
     }
   },
@@ -512,7 +512,7 @@ export default Vue.extend({
       });
       this.$emit("simulate-card", this.card, this.model);
     },
-    toggleColorScheme() {
+    setColorScheme() {
       if (this.card.showDiffFVAScore) {
         this.escherBuilder.settings.set("reaction_scale", [
           { type: "min", color: "#a841d0", size: 20 },

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -154,6 +154,8 @@ export default Vue.extend({
           this.isLoadingMap = false;
           // Update the map state, since it will be reset whenever the map is
           // changed. Note that we don't need to update the model.
+          // Important: Any new logic to set map state that is added below, needs to be
+          // called here as well, otherwise it will reset when changing the map.
           if (this.model && this.model.model_serialized) {
             this.setReactionAdditions();
           }
@@ -161,6 +163,7 @@ export default Vue.extend({
           this.setGeneKnockouts();
           this.setConditionData();
           this.setFluxes();
+          this.toggleColorScheme();
         }, 10);
       };
 

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -141,6 +141,10 @@ export default Vue.extend({
   },
   watch: {
     mapData(mapData) {
+      // When the map is changed, recreate the Escher builder instead of simply
+      // calling `load_map`. We're doing this to work around a number of bugs
+      // where state in Escher is not properly retained after changing maps.
+      // See discussion in: https://github.com/DD-DeCaF/caffeine-vue/pull/118
       this.initializingEscher = true;
       // Recreating the Escher builder over an existing one doesn't work, so destroy
       // it by simply clearing the DOM element.

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -10,6 +10,7 @@
       @simulate-card="simulate"
       @click="isSidepanelOpen = false"
       :card="selectedCard"
+      :isLoadingMap="isLoadingMap"
       :mapData="mapData"
     />
     <v-btn
@@ -138,6 +139,7 @@ export default Vue.extend({
   data: () => ({
     isSidepanelOpen: true,
     escherBuilder: null,
+    isLoadingMap: false,
     mapData: null,
     selectedCardId: null,
     playingInterval: null,
@@ -215,6 +217,7 @@ export default Vue.extend({
   },
   methods: {
     changeMap() {
+      this.isLoadingMap = true;
       this.hasLoadMapError = false;
       axios
         .get(`${settings.apis.maps}/maps/${this.currentMapId}`)
@@ -224,6 +227,9 @@ export default Vue.extend({
         .catch(error => {
           this.mapData = null;
           this.hasLoadMapError = true;
+        })
+        .then(() => {
+          this.isLoadingMap = false;
         });
     },
     addDefaultCard(cardType, withDialog) {


### PR DESCRIPTION
There have been multiple reported issues of state not being synchronized
when changing maps. Additionally, there was the "double vision" bug. And
finally, [knockouts from visualized design jobs were not always shown
correctly on the map](https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/1008).

This change completely destroys and recreates Escher when map changes
and appears to solve all above issues.

As a consequence, the `onEscherReady` promise is no longer relevant.
Instead, watchers will check if the builder exists, and abort if it
doesn't. Then, when Escher is ready, state is always reapplied to make
sure that data for any aborted watcher is applied correctly.