### PR TITLE
fix: error when getting production

### DIFF
--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -268,7 +268,7 @@ export default Vue.extend({
     },
     production() {
       // If the objective is growth, ignore production.
-      if (this.card.objective.reaction.id === null) {
+      if (this.card.objective.reaction === null) {
         return null;
       }
       if (this.card.method === "fba" || this.card.method == "pfba") {


### PR DESCRIPTION
Instead of returning null, it was silently throwing an error

This condition is now consistent with https://github.com/DD-DeCaF/caffeine-vue/blob/77e2db6ab02427e6c7dbb30b0db18e905ba46fa2/src/views/InteractiveMap/Card.vue#L73