### PR TITLE
fix: keep results where growth or biomass is positive

### DIFF
--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -688,7 +688,7 @@ export default Vue.extend({
         ...this.prediction.result.diff_fva,
         ...this.prediction.result.opt_gene
       ]
-        .filter(pathway => pathway.biomass > 0)
+        .filter(pathway => pathway.biomass || pathway.product)
         .map((pathway, index) => ({
           id: index,
           ...pathway


### PR DESCRIPTION
Job results should be filtered out only if both growth and production are 0 or null