### PR TITLE
Use info icon for DiffFVA card dialog

### DIFF
--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -38,7 +38,7 @@ export interface Card {
   // `modified` is true when the user has made any change to the model, and it
   // can be saved. Not relevant for data-driven cards.
   modified: boolean;
-  type: string;
+  type: "Design" | "DataDriven" | "DiffFVA";
   // Design card fields
   objective: {
     reaction: Reaction | null;

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -23,7 +23,8 @@
           @open-method-help-dialog="showMethodHelpDialog = true"
           @load-data-error="$emit('load-data-error')"
         />
-        <v-icon color="white">edit</v-icon>
+        <v-icon v-if="card.type == 'DiffFVA'" color="white">info</v-icon>
+        <v-icon v-else color="white">edit</v-icon>
       </v-btn>
       <!-- Define the method help dialog here to avoid nested dialogs. -->
       <MethodHelpDialog


### PR DESCRIPTION
Though this might make more sense since the dialog is readonly.

![image](https://user-images.githubusercontent.com/64745/62113638-3afd1500-b2b5-11e9-83b8-c1f90cd039c3.png)