### PR TITLE
fix: highlight only reaction measurements with glow

### DIFF
--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -282,7 +282,9 @@ export default Vue.extend({
         return;
       }
       this.escherBuilder.set_highlight_reactions(
-        this.card.conditionData.measurements.map(m => m.id)
+        this.card.conditionData.measurements
+          .filter(m => m.type === "reaction")
+          .map(m => m.id)
       );
     },
     setFluxes() {


### PR DESCRIPTION
Measurements have a `type` field which can be "reaction" or "compound".

For a reaction, we should highlight the reaction id as measured. However for the compound, it's not so clear - we could find the exchange reaction and mark it as measured (since that's what we constrain) but many maps don't have the exchange reactions drawn.

In any case, the current logic was trying to find the compound identifier as a reaction and that's of course wrong.