### PR TITLE
Add MetaNetX metabolite autocomplete

### DIFF
--- a/src/components/AutocompleteMnxMetabolite.vue
+++ b/src/components/AutocompleteMnxMetabolite.vue
@@ -25,26 +25,26 @@ import {
   Annotation
 } from "./AutocompleteMnxMetabolite.vue";
 
-export interface MetaNetXReaction {
-  compartments: {
-    annotation: Annotation;
-    mnx_id: string;
-    name: string;
-    xref: string;
-  }[];
-  metabolites: MetaNetXMetabolite[];
-  reaction: {
-    mnx_id: string;
-    name: string | undefined;
-    ec: string;
-    equation_string: string;
-    equation_parsed: {
-      coefficient: number;
-      compartment_id: string;
-      metabolite_id: string;
-    }[];
-    annotation: Annotation;
-  };
+export interface MetaNetXMetabolite {
+  annotation: Annotation;
+  name: string;
+  mnx_id: string;
+  formula: string;
+}
+
+export interface Annotation {
+  bigg: string[];
+  chebi: string[];
+  deprecated: string[];
+  hmdb: string[];
+  kegg: string[];
+  metacyc: string[];
+  seed: string[];
+  reactome: string[];
+  sabiork: string[];
+  envipath: string[];
+  lipidmaps: string[];
+  slm: string[];
 }
 
 export default Vue.extend({

--- a/src/components/AutocompleteMnxReaction.vue
+++ b/src/components/AutocompleteMnxReaction.vue
@@ -66,7 +66,10 @@ interface Annotation {
 export default Vue.extend({
   name: "AutocompleteMnxReaction",
   inheritAttrs: false,
-  props: ["rules"],
+  props: {
+    rules: [Array, Object],
+    clearOnChange: Boolean
+  },
   data: () => ({
     addReactionItem: null,
     addReactionSearchResults: [] as MetaNetXReaction[],
@@ -138,10 +141,12 @@ export default Vue.extend({
       );
     },
     onChange(selectedReaction: MetaNetXReaction): void {
-      this.addReactionSearchQuery = null;
-      this.$nextTick(() => {
-        this.addReactionItem = null;
-      });
+      if (this.clearOnChange) {
+        this.addReactionSearchQuery = null;
+        this.$nextTick(() => {
+          this.addReactionItem = null;
+        });
+      }
 
       const reaction: Reaction = {
         id: selectedReaction.reaction.mnx_id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import FileUpload from "@/components/FileUpload.vue";
 import VSelectExtended from "@/components/VSelectExtended";
 import VAutocompleteExtended from "@/components/VAutocompleteExtended";
 import AutocompleteMnxReaction from "@/components/AutocompleteMnxReaction.vue";
+import AutocompleteMnxMetabolite from "@/components/AutocompleteMnxMetabolite.vue";
 import { initFromStorage } from "@/utils/startup";
 import * as Sentry from "@sentry/browser";
 import * as Integrations from "@sentry/integrations";
@@ -61,6 +62,7 @@ Vue.component("LoaderDialog", LoaderDialog);
 Vue.component("DeletionDialog", DeletionDialog);
 Vue.component("FileUpload", FileUpload);
 Vue.component("AutocompleteMnxReaction", AutocompleteMnxReaction);
+Vue.component("AutocompleteMnxMetabolite", AutocompleteMnxMetabolite);
 Vue.component("v-select-extended", VSelectExtended);
 Vue.component("v-autocomplete-extended", VAutocompleteExtended);
 

--- a/src/views/InteractiveMap/CardDialogDesign.vue
+++ b/src/views/InteractiveMap/CardDialogDesign.vue
@@ -41,6 +41,7 @@
       label="Add a reaction..."
       hint="Searches the entire <a href='https://www.metanetx.org/mnxdoc/mnxref.html'>MetaNetX</a> database for known reactions. Search by MNX ID, EC number or the reaction name."
       prepend-icon="add"
+      clear-on-change
       @change="addReaction"
     ></AutocompleteMnxReaction>
     <ReactionDialog


### PR DESCRIPTION
This can be used for compound autocomplete
- compound in Experiment tables (Metabolomics, Molar Yields, ..)
- compounds in New Medium dialog

(Requests in this component are not debounced and responses can be out of order)
(RxJS version of this component was on [mnx-metabolite branch](https://github.com/DD-DeCaF/caffeine-vue/compare/mnx-metabolite))