### PR TITLE
Update data-driven cards for new warehouse schema

### DIFF
--- a/src/components/CompoundLink.vue
+++ b/src/components/CompoundLink.vue
@@ -1,0 +1,33 @@
+<template>
+  <span>
+    <a v-if="link" :href="link" target="_blank">{{ identifier }}</a>
+    <span v-else>{{ identifier }} ({{ namespace }})</span>
+  </span>
+</template>
+
+<script lang="ts">
+/**
+ * For a given compound identifier + namespace, link to the relevant database if the
+ * namespace is recognized. Otherwise, simply print the identifier and namespace.
+ */
+
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "CompoundLink",
+  props: ["identifier", "namespace"],
+  computed: {
+    link() {
+      if (this.namespace === "bigg.metabolite") {
+        return `http://bigg.ucsd.edu/universal/metabolites/${this.identifier}`;
+      } else if (this.namespace === "CHEBI") {
+        return `https://www.ebi.ac.uk/chebi/searchId.do?chebiId=${
+          this.identifier
+        }`;
+      } else {
+        return null;
+      }
+    }
+  }
+});
+</script>

--- a/src/components/ReactionLink.vue
+++ b/src/components/ReactionLink.vue
@@ -1,0 +1,29 @@
+<template>
+  <span>
+    <a v-if="link" :href="link" target="_blank">{{ identifier }}</a>
+    <span v-else>{{ identifier }} ({{ namespace }})</span>
+  </span>
+</template>
+
+<script lang="ts">
+/**
+ * For a given reaction identifier + namespace, link to the relevant database if the
+ * namespace is recognized. Otherwise, simply print the identifier and namespace.
+ */
+
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "ReactionLink",
+  props: ["identifier", "namespace"],
+  computed: {
+    link() {
+      if (this.namespace === "bigg.reaction") {
+        return `http://bigg.ucsd.edu/universal/reactions/${this.identifier}`;
+      } else {
+        return null;
+      }
+    }
+  }
+});
+</script>

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -49,10 +49,10 @@ export interface Card {
   editedBounds: Reaction[];
   // Data-driven card fields
   experiment: any;
-  condition: any;
   conditionData: any;
-  conditionWarnings: any[];
-  conditionErrors: any[];
+  sample: any;
+  sampleWarnings: any[];
+  sampleErrors: any[];
   // General simulation fields
   isSimulating: boolean;
   hasSimulationError: boolean;

--- a/src/views/Designs.vue
+++ b/src/views/Designs.vue
@@ -478,10 +478,10 @@ export default Vue.extend({
           editedBounds: design.design.constraints,
           // Data-driven card fields
           experiment: null,
-          condition: null,
           conditionData: null,
-          conditionWarnings: [],
-          conditionErrors: [],
+          sample: null,
+          sampleWarnings: [],
+          sampleErrors: [],
           // General simulation fields
           isSimulating: false,
           hasSimulationError: false,

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -130,10 +130,37 @@
       </v-container>
       <v-container v-if="card.type == 'DataDriven'" fluid class="pa-0">
         <v-layout>
-          <v-flex>Conditions:</v-flex>
+          <v-flex>Strain:</v-flex>
           <v-flex class="text-xs-right">
-            <span v-if="card.condition === null"><em>Not selected</em></span>
-            <span v-else>{{ card.condition.name }}</span>
+            <span v-if="card.conditionData === null"
+              ><em>Not selected</em></span
+            >
+            <span v-else>{{ card.conditionData.strain.name }}</span>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container v-if="card.type == 'DataDriven'" fluid class="pa-0">
+        <v-layout>
+          <v-flex>Medium:</v-flex>
+          <v-flex class="text-xs-right">
+            <span v-if="card.conditionData === null"
+              ><em>Not selected</em></span
+            >
+            <span v-else>{{ card.conditionData.medium.name }}</span>
+          </v-flex>
+        </v-layout>
+      </v-container>
+      <v-container v-if="card.type == 'DataDriven'" fluid class="pa-0">
+        <v-layout>
+          <v-flex>Sample:</v-flex>
+          <v-flex class="text-xs-right">
+            <span v-if="card.sample === null"><em>Not selected</em></span>
+            <span v-else>
+              {{ card.sample.start_time }}
+              <span v-if="card.sample.end_time">{{
+                card.sample.end_time
+              }}</span>
+            </span>
           </v-flex>
         </v-layout>
       </v-container>

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -221,13 +221,11 @@ export default Vue.extend({
       this.conditions = [];
       this.isLoadingConditions = true;
       axios
-        .get(
-          `${settings.apis.warehouse}/experiments/${
-            this.card.experiment.id
-          }/conditions`
-        )
+        .get(`${settings.apis.warehouse}/conditions`)
         .then(response => {
-          this.conditions = response.data;
+          this.conditions = response.data.filter(condition => {
+            return condition.experiment_id === this.card.experiment.id;
+          });
         })
         .catch(error => {
           this.$emit("load-data-error");

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -14,23 +14,45 @@
       ></v-autocomplete-extended>
 
       <v-autocomplete-extended
-        class="ml-2"
+        class="ml-2 mr-2"
         label="Conditions"
         :items="conditions"
-        v-model="cardCondition"
+        v-model="selectedCondition"
         autoselectOnlyOption
         :loading="isLoadingConditions"
         :disabled="conditions === []"
         item-text="name"
         item-value="id"
-        placeholder="Choose the conditions you wish to simulate"
+        placeholder="Choose the experimental conditions you wish to simulate..."
+        return-object
+      ></v-autocomplete-extended>
+
+      <v-autocomplete-extended
+        class="ml-2"
+        label="Sample"
+        :items="samples"
+        v-model="cardSample"
+        autoselectOnlyOption
+        :loading="isLoadingConditionData"
+        :disabled="samples === []"
+        item-text="start_time"
+        item-value="id"
+        placeholder="Choose the sample you wish to simulate..."
         return-object
       ></v-autocomplete-extended>
     </v-layout>
 
+    <span
+      v-if="isModifyingModel"
+      class="subheading font-weight-thin text-sm-center mb-2"
+    >
+      We are currently figuring out how to enrich the metabolic model with the
+      experimental data. This takes a few seconds, so please sit tight.
+      Meanwhile, feel free to inspect the data below.
+    </span>
     <v-progress-linear
       :indeterminate="true"
-      v-if="isLoadingConditionData"
+      v-if="isModifyingModel"
     ></v-progress-linear>
 
     <div v-if="organismMismatch" class="mb-2">
@@ -42,83 +64,246 @@
       </v-alert>
     </div>
 
-    <v-layout v-if="card.conditionData" column>
+    <v-layout v-if="card.conditionData && card.sample" column>
       <v-flex mb-1>
         <v-card>
-          <v-subheader>Genotype changes</v-subheader>
-          <v-list>
-            <v-list-tile v-for="gene in genotypes" :key="gene">
-              <v-list-tile-content>
-                <v-list-tile-title v-text="gene"></v-list-tile-title>
-              </v-list-tile-content>
-            </v-list-tile>
-          </v-list>
+          <v-subheader>Strain {{ card.conditionData.strain.name }}</v-subheader>
+          <v-card-text>
+            <code class="px-2">{{ card.conditionData.strain.genotype }}</code>
+            <p class="mt-2">
+              The genotype above is described in
+              <a href="https://gnomic.readthedocs.io">gnomic</a> syntax, a
+              grammar to represent genotypes and phenotypes developed at DTU
+              Biosustain.
+            </p>
+          </v-card-text>
         </v-card>
       </v-flex>
       <v-flex mb-1>
         <v-card>
-          <v-subheader>Measurements</v-subheader>
-          <v-list>
-            <!-- TODO: Handle non-bigg namespaces -->
-            <!-- See: https://github.com/DD-DeCaF/caffeine-vue/issues/46 -->
-            <v-list-tile
-              v-for="measurement in card.conditionData.measurements"
-              :key="measurement.id"
-              :href="`http://bigg.ucsd.edu/search?query=${measurement.id}`"
-              target="_blank"
-            >
-              <v-list-tile-content>
-                <v-list-tile-title>
-                  {{ measurement.id }}: {{ measurement.measurements }} mmol
-                  g<sup>-1</sup> h<sup>-1</sup>
-                </v-list-tile-title>
-              </v-list-tile-content>
-            </v-list-tile>
-          </v-list>
+          <v-subheader>Medium {{ card.conditionData.medium.name }}</v-subheader>
+          <v-data-table
+            :headers="mediumHeaders"
+            :items="card.conditionData.medium.compounds"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: compound }">
+              <td>{{ compound.compound_name }}</td>
+              <td>
+                <CompoundLink
+                  :identifier="compound.compound_identifier"
+                  :namespace="compound.compound_namespace"
+                />
+              </td>
+              <td>
+                <span v-if="compound.mass_concentration">
+                  {{ compound.mass_concentration }} <em>mmol/l</em>
+                </span>
+                <span v-else>Unspecified</span>
+              </td>
+            </template>
+          </v-data-table>
         </v-card>
       </v-flex>
-      <v-flex mb-1>
+
+      <v-flex mb-1 v-if="card.sample.fluxomics.length > 0">
         <v-card>
-          <v-subheader>Medium</v-subheader>
-          <v-list>
-            <!-- TODO: Handle non-chebi namespaces -->
-            <!-- See: https://github.com/DD-DeCaF/caffeine-vue/issues/46 -->
-            <v-list-tile
-              v-for="medium in card.conditionData.medium"
-              :key="medium.id"
-              :href="
-                `https://www.ebi.ac.uk/chebi/searchId.do?chebiId=${medium.id}`
-              "
-              target="_blank"
-            >
-              <v-list-tile-content>
-                <v-list-tile-title>{{ medium.id }}</v-list-tile-title>
-              </v-list-tile-content>
-            </v-list-tile>
-          </v-list>
+          <v-subheader>Fluxomics</v-subheader>
+          <v-data-table
+            :headers="fluxomicsHeaders"
+            :items="card.sample.fluxomics"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: reaction }">
+              <td>{{ reaction.reaction_name }}</td>
+              <td>
+                <ReactionLink
+                  :identifier="reaction.reaction_identifier"
+                  :namespace="reaction.reaction_namespace"
+                />
+              </td>
+              <td>
+                {{ reaction.measurement }}
+                <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+              </td>
+              <td>
+                <span v-if="reaction.uncertainty">
+                  {{ reaction.uncertainty }}
+                  <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
+        </v-card>
+      </v-flex>
+
+      <v-flex mb-1 v-if="card.sample.metabolomics.length > 0">
+        <v-card>
+          <v-subheader>Metabolomics</v-subheader>
+          <v-data-table
+            :headers="metabolomicsHeaders"
+            :items="card.sample.metabolomics"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: metabolite }">
+              <td>{{ metabolite.compound_name }}</td>
+              <td>
+                <CompoundLink
+                  :identifier="metabolite.compound_identifier"
+                  :namespace="metabolite.compound_namespace"
+                />
+              </td>
+              <td>
+                {{ metabolite.measurement }}
+                <em>mmol/l</em>
+              </td>
+              <td>
+                <span v-if="metabolite.uncertainty">
+                  {{ metabolite.uncertainty }}
+                  <em>mmol/l</em>
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
+        </v-card>
+      </v-flex>
+
+      <v-flex mb-1 v-if="card.sample.uptake_secretion_rates.length > 0">
+        <v-card>
+          <v-subheader>Uptake secretion rates</v-subheader>
+          <v-data-table
+            :headers="uptakeSecretionRatesHeaders"
+            :items="card.sample.uptake_secretion_rates"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: rate }">
+              <td>{{ rate.compound_name }}</td>
+              <td>
+                <CompoundLink
+                  :identifier="rate.compound_identifier"
+                  :namespace="rate.compound_namespace"
+                />
+              </td>
+              <td>
+                {{ rate.measurement }}
+                <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+              </td>
+              <td>
+                <span v-if="rate.uncertainty">
+                  {{ rate.uncertainty }}
+                  <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
+        </v-card>
+      </v-flex>
+
+      <v-flex mb-1 v-if="card.sample.molar_yields.length > 0">
+        <v-card>
+          <v-subheader>Molar yields</v-subheader>
+          <v-data-table
+            :headers="molarYieldsHeaders"
+            :items="card.sample.molar_yields"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: molarYield }">
+              <td>{{ molarYield.product_name }}</td>
+              <td>
+                <CompoundLink
+                  :identifier="molarYield.product_identifier"
+                  :namespace="molarYield.product_namespace"
+                />
+              </td>
+              <td>{{ molarYield.substrate_name }}</td>
+              <td>
+                <CompoundLink
+                  :identifier="molarYield.substrate_identifier"
+                  :namespace="molarYield.substrate_namespace"
+                />
+              </td>
+              <td>
+                {{ molarYield.measurement }}
+                <em
+                  >mmol-{{ molarYield.product_name }} / mmol-{{
+                    molarYield.substrate_name
+                  }}</em
+                >
+              </td>
+              <td>
+                <span v-if="molarYield.uncertainty">
+                  {{ molarYield.uncertainty }}
+                  <em
+                    >mmol-{{ molarYield.product_name }} / mmol-{{
+                      molarYield.substrate_name
+                    }}</em
+                  >
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
+        </v-card>
+      </v-flex>
+
+      <v-flex mb-1 v-if="card.sample.growth_rate">
+        <v-card>
+          <v-subheader>Growth rate</v-subheader>
+          <v-data-table
+            :headers="growthRateHeaders"
+            :items="[card.sample.growth_rate]"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: growthRate }">
+              <td>
+                {{ growthRate.measurement }}
+                <em>h<sup>-1</sup></em>
+              </td>
+              <td>
+                <span v-if="growthRate.uncertainty">
+                  {{ growthRate.uncertainty }}
+                  <em>h<sup>-1</sup></em>
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
         </v-card>
       </v-flex>
     </v-layout>
 
-    <ModificationsTable :modifications="modifications" :readonly="true" />
+    <ModificationsTable
+      v-if="modifications.length > 0"
+      :modifications="modifications"
+      :readonly="true"
+    />
 
-    <v-expansion-panel v-if="card.conditionWarnings.length" class="mt-2">
+    <v-expansion-panel v-if="card.sampleWarnings.length" class="mt-2">
       <v-expansion-panel-content>
         <template v-slot:header>
           <div>
             <v-badge color="warning">
               <template v-slot:badge
-                >{{ card.conditionWarnings.length }}
+                >{{ card.sampleWarnings.length }}
               </template>
               <span>Warnings</span>
             </v-badge>
           </div>
         </template>
-        <div
-          v-for="warning in card.conditionWarnings"
-          :key="warning"
-          class="mt-2"
-        >
+        <div v-for="warning in card.sampleWarnings" :key="warning" class="mt-2">
           <v-alert :value="true" type="warning">
             {{ warning }}
           </v-alert>
@@ -126,19 +311,19 @@
       </v-expansion-panel-content>
     </v-expansion-panel>
 
-    <v-expansion-panel v-if="card.conditionErrors.length" class="mt-2">
+    <v-expansion-panel v-if="card.sampleErrors.length" class="mt-2">
       <v-expansion-panel-content>
         <template v-slot:header>
           <div>
             <v-badge color="error">
               <template v-slot:badge
-                >{{ card.conditionErrors.length }}
+                >{{ card.sampleErrors.length }}
               </template>
               <span>Errors</span>
             </v-badge>
           </div>
         </template>
-        <div v-for="error in card.conditionErrors" :key="error" class="mt-2">
+        <div v-for="error in card.sampleErrors" :key="error" class="mt-2">
           <v-alert :value="true" type="error">
             {{ error }}
           </v-alert>
@@ -154,40 +339,80 @@ import { mapMutations } from "vuex";
 import axios from "axios";
 import * as settings from "@/utils/settings";
 import ModificationsTable from "@/components/ModificationsTable.vue";
+import ReactionLink from "@/components/ReactionLink.vue";
+import CompoundLink from "@/components/CompoundLink.vue";
 import { Metabolite } from "@/store/modules/interactiveMap";
 import { buildReactionString } from "@/utils/reaction";
 
 export default Vue.extend({
   name: "CardDialogDataDriven",
   components: {
-    ModificationsTable
+    ModificationsTable,
+    ReactionLink,
+    CompoundLink
   },
   props: ["card", "modifications"],
   data: () => ({
     conditions: [],
+    selectedCondition: null,
     conditionOrganism: null,
     isLoadingConditions: false,
-    isLoadingConditionData: false
+    isLoadingConditionData: false,
+    isModifyingModel: false,
+    mediumHeaders: [
+      { text: "Compound", sortable: false },
+      { text: "Identifier", sortable: false },
+      {
+        text: "Mass concentration",
+        sortable: false
+      }
+    ],
+    fluxomicsHeaders: [
+      { text: "Reaction", sortable: false },
+      { text: "Identifier", sortable: false },
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ],
+    metabolomicsHeaders: [
+      { text: "Metabolite", sortable: false },
+      { text: "Identifier", sortable: false },
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ],
+    uptakeSecretionRatesHeaders: [
+      { text: "Compound", sortable: false },
+      { text: "Identifier", sortable: false },
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ],
+    molarYieldsHeaders: [
+      { text: "Product", sortable: false },
+      { text: "Product Identifier", sortable: false },
+      { text: "Substrate", sortable: false },
+      { text: "Substrate Identifier", sortable: false },
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ],
+    growthRateHeaders: [
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ]
   }),
   computed: {
     experiments() {
       return this.$store.state.experiments.experiments;
+    },
+    samples() {
+      if (!this.card.conditionData) {
+        return [];
+      }
+      return this.card.conditionData.samples;
     },
     organismMismatch() {
       if (!this.card.organism || !this.conditionOrganism) {
         return false;
       }
       return this.card.organism.id != this.conditionOrganism.id;
-    },
-    genotypes() {
-      if (!this.card.conditionData) {
-        return [];
-      }
-      const genesFlattened: object[] = [];
-      this.card.conditionData.genotype.forEach(geneString => {
-        geneString.split(",").forEach(gene => genesFlattened.push(gene));
-      });
-      return genesFlattened;
     },
     cardExperiment: {
       get() {
@@ -200,14 +425,14 @@ export default Vue.extend({
         });
       }
     },
-    cardCondition: {
+    cardSample: {
       get() {
-        return this.card.condition;
+        return this.card.sample;
       },
-      set(condition) {
+      set(sample) {
         this.updateCard({
           uuid: this.card.uuid,
-          props: { condition: condition }
+          props: { sample: sample }
         });
       }
     }
@@ -234,46 +459,33 @@ export default Vue.extend({
           this.isLoadingConditions = false;
         });
     },
-    "card.condition"() {
+    selectedCondition() {
       this.conditionOrganism = null;
       this.updateCard({
         uuid: this.card.uuid,
-        props: { conditionData: null }
+        props: { conditionData: null, sample: null }
       });
 
-      if (!this.card.condition) {
+      if (!this.selectedCondition) {
         return;
       }
-
-      // Load the organism based on conditions strain
-      this.$emit("is-loading-organism", true);
-      axios
-        .get(
-          `${settings.apis.warehouse}/strains/${this.card.condition.strain_id}`
-        )
-        .then(response => {
-          this.conditionOrganism = this.$store.getters[
-            "organisms/getOrganismById"
-          ](response.data.organism_id);
-        })
-        .catch(error => {
-          this.$emit("load-data-error");
-        })
-        .then(() => {
-          this.$emit("is-loading-organism", false);
-        });
 
       // Load condition data
       this.isLoadingConditionData = true;
       axios
         .get(
-          `${settings.apis.warehouse}/conditions/${this.card.condition.id}/data`
+          `${settings.apis.warehouse}/conditions/${
+            this.selectedCondition.id
+          }/data`
         )
         .then(response => {
           this.updateCard({
             uuid: this.card.uuid,
             props: { conditionData: response.data }
           });
+          this.conditionOrganism = this.$store.getters[
+            "organisms/getOrganismById"
+          ](response.data.strain.organism_id);
         })
         .catch(error => {
           this.$emit("load-data-error");
@@ -282,8 +494,8 @@ export default Vue.extend({
           this.isLoadingConditionData = false;
         });
     },
-    "card.conditionData"() {
-      if (!this.card.conditionData) {
+    "card.sample"() {
+      if (!this.card.modelId || !this.card.sample) {
         return;
       }
 
@@ -294,17 +506,72 @@ export default Vue.extend({
       this.updateCard({
         uuid: this.card.uuid,
         props: {
-          conditionWarnings: [],
-          conditionErrors: [],
+          sampleWarnings: [],
+          sampleErrors: [],
           isSimulating: true,
           hasSimulationError: false
         }
       });
 
+      // Map data to the expected payload for modification service
+      const medium = this.card.conditionData.medium.compounds.map(c => ({
+        name: c.compound_name,
+        identifier: c.compound_identifier,
+        namespace: c.compound_namespace,
+        mass_concentration: c.mass_concentration
+      }));
+      const genotype = this.card.conditionData.strain.genotype;
+      const fluxomics = this.card.sample.fluxomics.map(f => ({
+        name: f.reaction_name,
+        identifier: f.reaction_identifier,
+        namespace: f.reaction_namespace,
+        measurement: f.measurement,
+        uncertainty: f.uncertainty
+      }));
+      const metabolomics = this.card.sample.metabolomics.map(m => ({
+        name: m.compound_name,
+        identifier: m.compound_identifier,
+        namespace: m.compound_namespace,
+        measurement: m.measurement,
+        uncertainty: m.uncertainty
+      }));
+      const uptakeSecretionRates = this.card.sample.uptake_secretion_rates.map(
+        u => ({
+          name: u.compound_name,
+          identifier: u.compound_identifier,
+          namespace: u.compound_namespace,
+          measurement: u.measurement,
+          uncertainty: u.uncertainty
+        })
+      );
+      const molarYields = this.card.sample.molar_yields.map(m => ({
+        product_name: m.product_name,
+        product_identifier: m.product_identifier,
+        product_namespace: m.product_namespace,
+        substrate_name: m.substrate_name,
+        substrate_identifier: m.substrate_identifier,
+        substrate_namespace: m.substrate_namespace,
+        measurement: m.measurement,
+        uncertainty: m.uncertainty
+      }));
+      const growthRate = {
+        measurement: this.card.sample.growth_rate.measurement,
+        uncertainty: this.card.sample.growth_rate.uncertainty
+      };
+
+      this.isModifyingModel = true;
       axios
         .post(
           `${settings.apis.simulations}/models/${this.card.modelId}/modify`,
-          this.card.conditionData
+          {
+            medium: medium,
+            genotype: genotype,
+            fluxomics: fluxomics,
+            metabolomics: metabolomics,
+            uptake_secretion_rates: uptakeSecretionRates,
+            molar_yields: molarYields,
+            growth_rate: growthRate
+          }
         )
         .then(response => {
           // Save all modifications to the card
@@ -385,7 +652,7 @@ export default Vue.extend({
           // waiting for the actual simulation to finish.
           this.updateCard({
             uuid: this.card.uuid,
-            props: { conditionWarnings: response.data.warnings }
+            props: { sampleWarnings: response.data.warnings }
           });
           this.$emit("simulate-card");
         })
@@ -398,10 +665,13 @@ export default Vue.extend({
           if (error.response && error.response.data.errors) {
             this.updateCard({
               uuid: this.card.uuid,
-              props: { conditionErrors: error.response.data.errors }
+              props: { sampleErrors: error.response.data.errors }
             });
           }
           this.$emit("simulation-error");
+        })
+        .then(() => {
+          this.isModifyingModel = false;
         });
     }
   },

--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -291,9 +291,7 @@ export default Vue.extend({
         return;
       }
       this.escherBuilder.set_highlight_reactions(
-        this.card.conditionData.measurements
-          .filter(m => m.type === "reaction")
-          .map(m => m.id)
+        this.card.conditionData.fluxomics.map(m => m.identifier)
       );
     },
     setFluxes() {

--- a/src/views/InteractiveMap/InteractiveMap.vue
+++ b/src/views/InteractiveMap/InteractiveMap.vue
@@ -277,10 +277,10 @@ export default Vue.extend({
         editedBounds: [],
         // Data-driven card fields
         experiment: null,
-        condition: null,
         conditionData: null,
-        conditionWarnings: [],
-        conditionErrors: [],
+        sample: null,
+        sampleWarnings: [],
+        sampleErrors: [],
         // General simulation fields
         isSimulating: false,
         hasSimulationError: false,

--- a/src/views/Jobs/JobResultsTable.vue
+++ b/src/views/Jobs/JobResultsTable.vue
@@ -956,10 +956,10 @@ export default Vue.extend({
               editedBounds: [],
               // Data-driven card fields
               experiment: null,
-              condition: null,
               conditionData: null,
-              conditionWarnings: [],
-              conditionErrors: [],
+              sample: null,
+              sampleWarnings: [],
+              sampleErrors: [],
               // General simulation fields
               isSimulating: false,
               hasSimulationError: false,


### PR DESCRIPTION
- Handles experimental data correctly and forwards to simulation service (depends on https://github.com/DD-DeCaF/simulations/pull/145)
- New components to display compound/reaction identifier and link to remote database if recognized (more database URLs can easily be added)
- Tables to list experimental data are modified a bit, now a separate table for each measurement type