### PR TITLE
MNX search debouncing & ordering

### DIFF
--- a/src/components/AutocompleteMnxReaction.vue
+++ b/src/components/AutocompleteMnxReaction.vue
@@ -20,6 +20,7 @@
 <script lang="ts">
 import Vue from "vue";
 import axios from "axios";
+import { debounce } from "lodash";
 import * as settings from "@/utils/settings";
 import { Reaction } from "@/store/modules/interactiveMap";
 import {
@@ -69,20 +70,20 @@ export default Vue.extend({
       "Could not search MetaNetX for reactions, please check your internet connection."
   }),
   watch: {
-    searchQuery(query: string): void {
+    searchQuery: debounce(function() {
       this.searchResults = [];
       if (
-        query === null ||
-        query.trim().length === 0 ||
+        this.searchQuery === null ||
+        this.searchQuery.trim().length === 0 ||
         (this.selectedValue &&
-          query === this.reactionDisplay(this.selectedValue))
+          this.searchQuery === this.reactionDisplay(this.selectedValue))
       ) {
         return;
       }
       this.isLoading = true;
       this.requestError = false;
       axios
-        .get(`${settings.apis.metanetx}/reactions?query=${query}`)
+        .get(`${settings.apis.metanetx}/reactions?query=${this.searchQuery}`)
         .then(response => {
           this.searchResults = response.data;
         })
@@ -92,7 +93,7 @@ export default Vue.extend({
         .then(() => {
           this.isLoading = false;
         });
-    },
+    }, 500),
     forceSearchQuery(): void {
       this.loadForcedSearchQuery();
     }


### PR DESCRIPTION
Here's my suggestion of how to achieve debouncing and order guarantee without RxJS.

- For debouncing, turns out it's straight forward to use [`lodash`](https://lodash.com/docs/4.17.15#debounce) which is already a dependency.
- To guarantee search results are for the latest query, a unique ID is assigned to the request promise and compared when it resolves. If the ID has changed the results are ignored in favor of the results of another request.