### PR TITLE
fix: avoid using destroyed handler

### DIFF
--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -465,15 +465,16 @@ export default Vue.extend({
   mounted() {
     if (this.card.withDialog) {
       this.isCardDialogVisible = true;
+      // Now that we've opened the dialog, disable the toggle. Otherwise, it
+      // would reactivate and show the dialog again if the user navigates away
+      // (destroys the component) and re-navigates back to the interactive map.
+      this.updateCard({
+        uuid: this.card.uuid,
+        props: {
+          withDialog: false
+        }
+      });
     }
-  },
-  destroyed() {
-    this.updateCard({
-      uuid: this.card.uuid,
-      props: {
-        withDialog: false
-      }
-    });
   },
   methods: {
     selectCard() {


### PR DESCRIPTION
Fixes https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/1031

The destroyed handler works when navigating away (and keeping the cards
in the store), but fails when the card has been removed.

Instead, just deactivate the dialog toggle right after it has been used.
This way we don't need to worry about the component's lifecycle.