### PR TITLE
Proteomics

### DIFF
--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -463,6 +463,10 @@
                             proteomicsItem
                           )
                         ]"
+                        :forceSearchQuery="
+                          proteomicsItem.protein &&
+                            proteomicsItem.protein._pastedText
+                        "
                       />
                     </td>
                     <td>

--- a/src/components/UniprotInput.vue
+++ b/src/components/UniprotInput.vue
@@ -85,9 +85,6 @@ export default Vue.extend({
     dialog: false
   }),
   computed: {},
-  created() {
-    this.debouncedQuery = debounce(this.query, 500);
-  },
   watch: {
     forceSearchQuery: {
       // Watcher needs to be immediate to trigger when copy-paste creates
@@ -115,6 +112,9 @@ export default Vue.extend({
         this.triggerQuery();
       }
     }
+  },
+  created() {
+    this.debouncedQuery = debounce(this.query, 500);
   },
   methods: {
     hint() {

--- a/src/components/UniprotInput.vue
+++ b/src/components/UniprotInput.vue
@@ -101,6 +101,9 @@ export default Vue.extend({
       this.requestError = false;
       // Pretend we already started searching, even though it's debounced
       this.isLoading = true;
+      // Note: Didn't yet implement cancelling stale requests here. Should
+      // rarely results in wrong response order though, because of the 500ms
+      // debounce.
       this.debouncedQuery(identifier);
     },
     query(identifier: string) {

--- a/src/components/UniprotInput.vue
+++ b/src/components/UniprotInput.vue
@@ -1,0 +1,151 @@
+<template>
+  <div>
+    <v-text-field
+      label="Protein"
+      :loading="isLoading"
+      :hint="hint()"
+      persistent-hint
+      :append-outer-icon="protein ? 'info' : ''"
+      :rules="[requestErrorRule(requestError), ...(rules || [])]"
+      @input="inputChanged"
+      @click:append-outer="dialog = true"
+      @paste="$emit('paste', $event)"
+    ></v-text-field>
+    <v-dialog v-model="dialog" width="500">
+      <v-card v-if="protein">
+        <v-card-title
+          class="headline primary lighten-2 white--text"
+          primary-title
+        >
+          {{ protein.identifier }}
+        </v-card-title>
+
+        <v-card-text>
+          <table class="protein-table">
+            <tr>
+              <th>Name</th>
+              <td>{{ protein.name }}</td>
+            </tr>
+            <tr>
+              <th>Identifier</th>
+              <td>{{ protein.identifier }}</td>
+            </tr>
+            <tr>
+              <th>Gene</th>
+              <td>{{ protein.gene }}</td>
+            </tr>
+            <tr>
+              <th>External link</th>
+              <td>
+                <a
+                  :href="
+                    `https://www.uniprot.org/uniprot/${protein.identifier}`
+                  "
+                  target="_blank"
+                  >Open in UniProtKB</a
+                >
+              </td>
+            </tr>
+          </table>
+        </v-card-text>
+
+        <v-divider></v-divider>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" flat @click="dialog = false">
+            Close
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import axios from "axios";
+import { debounce } from "lodash";
+
+export default Vue.extend({
+  name: "UniprotInput",
+  props: {
+    rules: [Array, Object]
+  },
+  data: () => ({
+    debouncedQuery: null,
+    isLoading: false,
+    requestError: false,
+    requestErrorRule: error =>
+      !error ||
+      "Could not query UniProtKB. Their service or your internet connection might be down.",
+    protein: null,
+    dialog: false
+  }),
+  computed: {},
+  created() {
+    this.debouncedQuery = debounce(this.query, 500);
+  },
+  methods: {
+    hint() {
+      if (this.protein) {
+        return `${this.protein.identifier} (${this.protein.name})`;
+      } else {
+        return `Enter any valid <a href="https://www.uniprot.org/uniprot/" target="_blank">UniProtKB identifier</a>.`;
+      }
+    },
+    inputChanged(identifier: string) {
+      // Reset state
+      this.protein = null;
+      this.$emit("change", this.protein);
+      this.requestError = false;
+      // Pretend we already started searching, even though it's debounced
+      this.isLoading = true;
+      this.debouncedQuery(identifier);
+    },
+    query(identifier: string) {
+      axios
+        .get(`https://www.uniprot.org/uniprot/${identifier}.xml`)
+        .then(response => {
+          // Parse the XML response, looking for name, identifier and gene.
+          const doc = new DOMParser().parseFromString(
+            response.data,
+            "text/xml"
+          );
+          const name = doc.querySelector(
+            "entry > protein > recommendedName > fullName"
+          );
+          const identifier = doc.querySelector("entry > name");
+          const gene = doc.querySelector("entry > gene > name[type='primary']");
+          this.protein = {
+            name: name ? name.innerHTML : "Unknown",
+            identifier: identifier ? identifier.innerHTML : "Unknown",
+            gene: gene ? gene.innerHTML : "Unknown"
+          };
+          this.$emit("change", this.protein);
+        })
+        .catch(error => {
+          if (error.response && error.response.status === 404) {
+            // Not found - no need to take action; since `this.protein` is
+            // already null and will not pass validation.
+          } else {
+            this.requestError = true;
+          }
+        })
+        .then(() => {
+          this.isLoading = false;
+        });
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.protein-table {
+  width: 100%;
+
+  th {
+    text-align: left;
+  }
+}
+</style>

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -592,6 +592,14 @@ export default Vue.extend({
         measurement: m.measurement,
         uncertainty: m.uncertainty
       }));
+      // TODO: Should proteomics be excluded if chosen model is not
+      // enzyme-constrained? Currently, the backend will give a warning and
+      // ignore the data if that happens.
+      const proteomics = this.card.sample.proteomics.map(p => ({
+        identifier: p.identifier,
+        measurement: p.measurement,
+        uncertainty: p.uncertainty
+      }));
       const uptakeSecretionRates = this.card.sample.uptake_secretion_rates.map(
         u => ({
           name: u.compound_name,
@@ -627,6 +635,7 @@ export default Vue.extend({
             genotype: genotype,
             fluxomics: fluxomics,
             metabolomics: metabolomics,
+            proteomics: proteomics,
             uptake_secretion_rates: uptakeSecretionRates,
             molar_yields: molarYields,
             growth_rate: growthRate

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -68,7 +68,7 @@
       <v-flex mb-1>
         <v-card>
           <v-subheader>Strain {{ card.conditionData.strain.name }}</v-subheader>
-          <v-card-text>
+          <v-card-text v-if="card.conditionData.strain.genotype">
             <code class="px-2">{{ card.conditionData.strain.genotype }}</code>
             <p class="mt-2">
               The genotype above is described in
@@ -76,6 +76,9 @@
               grammar to represent genotypes and phenotypes developed at DTU
               Biosustain.
             </p>
+          </v-card-text>
+          <v-card-text v-else>
+            There are no genotype modifications in this strain.
           </v-card-text>
         </v-card>
       </v-flex>

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -177,6 +177,46 @@
         </v-card>
       </v-flex>
 
+      <v-flex mb-1 v-if="card.sample.proteomics.length > 0">
+        <v-card>
+          <v-subheader>Proteomics</v-subheader>
+          <v-data-table
+            :headers="proteomicsHeaders"
+            :items="card.sample.proteomics"
+            class="elevation-1"
+          >
+            <template v-slot:items="{ item: protein }">
+              <td>{{ protein.name }}</td>
+              <td>
+                <a
+                  :href="
+                    `https://www.uniprot.org/uniprot/${protein.identifier}`
+                  "
+                  target="_blank"
+                  >{{ protein.identifier }}</a
+                >
+              </td>
+              <td>
+                {{ protein.gene }}
+              </td>
+              <td>
+                {{ protein.measurement }}
+                <em>mmol/l</em>
+              </td>
+              <td>
+                <span v-if="protein.uncertainty">
+                  {{ protein.uncertainty }}
+                  <em>mmol/l</em>
+                </span>
+                <span v-else>
+                  No uncertainty
+                </span>
+              </td>
+            </template>
+          </v-data-table>
+        </v-card>
+      </v-flex>
+
       <v-flex mb-1 v-if="card.sample.uptake_secretion_rates.length > 0">
         <v-card>
           <v-subheader>Uptake secretion rates</v-subheader>
@@ -379,6 +419,13 @@ export default Vue.extend({
     metabolomicsHeaders: [
       { text: "Metabolite", sortable: false },
       { text: "Identifier", sortable: false },
+      { text: "Measurement", sortable: false },
+      { text: "Uncertainty", sortable: false }
+    ],
+    proteomicsHeaders: [
+      { text: "Protein", sortable: false },
+      { text: "Identifier", sortable: false },
+      { text: "Gene", sortable: false },
       { text: "Measurement", sortable: false },
       { text: "Uncertainty", sortable: false }
     ],


### PR DESCRIPTION
- Add proteomics table in new experiment dialog
  - Uses new Uniprot component which matches against https://www.uniprot.org/uniprot/ (service doesn't provide search, so needs to be exact match)
- Show proteomics in data driven card dialog
- Unrelated fix: Better display if strain has no genotype modifications

https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/1082
Related backend change: https://github.com/DD-DeCaF/warehouse/pull/20