### PR TITLE
Data driven dialog

### DIFF
--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -15,9 +15,20 @@
 
       <v-btn flat icon @click.stop="isCardDialogVisible = true">
         <CardDialog
+          v-if="card.type !== 'DataDriven'"
           v-model="isCardDialogVisible"
           :card="card"
           :model="model"
+          :modifications="modifications"
+          @simulate-card="simulateCard"
+          @simulation-error="$emit('simulation-error')"
+          @open-method-help-dialog="showMethodHelpDialog = true"
+          @load-data-error="$emit('load-data-error')"
+        />
+        <CardDialogDataDriven
+          v-else
+          v-model="isCardDialogVisible"
+          :card="card"
           :modifications="modifications"
           @simulate-card="simulateCard"
           @simulation-error="$emit('simulation-error')"
@@ -261,12 +272,14 @@ import { mapMutations } from "vuex";
 import axios from "axios";
 import * as settings from "@/utils/settings";
 import CardDialog from "@/views/InteractiveMap/CardDialog.vue";
+import CardDialogDataDriven from "@/views/InteractiveMap/CardDialogDataDriven.vue";
 import MethodHelpDialog from "@/views/InteractiveMap/MethodHelpDialog.vue";
 
 export default Vue.extend({
   name: "Card",
   components: {
     CardDialog,
+    CardDialogDataDriven,
     MethodHelpDialog
   },
   filters: {

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -29,6 +29,7 @@
           v-else
           v-model="isCardDialogVisible"
           :card="card"
+          :model="model"
           :modifications="modifications"
           @simulate-card="simulateCard"
           @simulation-error="$emit('simulation-error')"

--- a/src/views/InteractiveMap/CardDialog.vue
+++ b/src/views/InteractiveMap/CardDialog.vue
@@ -19,7 +19,6 @@
                 :items="organisms"
                 v-model="cardOrganism"
                 autoselectOnlyOption
-                :loading="isLoadingOrganism"
                 item-text="name"
                 item-value="id"
                 :hint="modificationsHint"
@@ -122,7 +121,6 @@ export default Vue.extend({
   },
   props: ["card", "model", "modifications", "value"],
   data: () => ({
-    isLoadingOrganism: false,
     methods: [
       { id: "fba", name: "Flux Balance Analysis (FBA)" },
       { id: "pfba", name: "Parsimonious FBA" },
@@ -246,9 +244,6 @@ export default Vue.extend({
         modified: true
       });
       this.$emit("simulate-card");
-    },
-    setLoadingOrganism(isLoading) {
-      this.isLoadingOrganism = isLoading;
     },
     ...mapMutations({
       updateCard: "interactiveMap/updateCard",

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -10,40 +10,13 @@
             <v-flex xs6>
               <p class="text-xs-right subheading mb-0 mt-2 font-italic">
                 Simulation status:
-                <span v-if="card.solverStatus">
-                  <span v-if="card.solverStatus == 'optimal'">Successful</span>
-                  <span v-else-if="card.solverStatus == 'infeasible'"
-                    >Infeasible</span
-                  >
-                </span>
-                <span v-else-if="card.sampleErrors.length > 0"
-                  >Can not integrate data</span
-                >
-                <span v-else-if="card.hasSimulationError"
-                  >Error during simulation</span
-                >
-                <span v-else-if="!model && !card.sample"
-                  >Waiting for model and sample</span
-                >
-                <span v-else-if="!model">Waiting for a model</span>
-                <span v-else-if="!card.sample">Waiting for a sample</span>
-                <span v-else-if="isModifyingModel">
-                  Integrating data...
-                  <v-progress-circular
-                    indeterminate
-                    size="12"
-                    :width="1"
-                  ></v-progress-circular>
-                </span>
-                <span v-else-if="card.isSimulating">
-                  Simulating...
-                  <v-progress-circular
-                    indeterminate
-                    size="12"
-                    :width="1"
-                  ></v-progress-circular>
-                </span>
-                <span v-else>Unknown</span>
+                <span>{{ simulationStatus.text }}</span>
+                <v-progress-circular
+                  v-if="simulationStatus.loader"
+                  indeterminate
+                  size="12"
+                  :width="1"
+                ></v-progress-circular>
               </p>
             </v-flex>
           </v-layout>
@@ -644,6 +617,36 @@ export default Vue.extend({
       set(value) {
         this.$emit("input", value);
       }
+    },
+    simulationStatus() {
+      const status = {
+        text: "Unknown",
+        loader: false
+      };
+      if (this.card.solverStatus) {
+        if (this.card.solverStatus === "optimal") {
+          status.text = "Successful";
+        } else if (this.card.solverStatus === "infeasible") {
+          status.text = "Infeasible";
+        }
+      } else if (this.card.sampleErrors.length > 0) {
+        status.text = "Can not integrate data";
+      } else if (this.card.hasSimulationError) {
+        status.text = "Error during simulation";
+      } else if (!this.model && !this.card.sample) {
+        status.text = "Please select model and sample";
+      } else if (!this.model) {
+        status.text = "Please select model";
+      } else if (!this.card.sample) {
+        status.text = "Please select sample";
+      } else if (this.isModifyingModel) {
+        status.text = "Integrating data...";
+        status.loader = true;
+      } else if (this.card.isSimulating) {
+        status.text = "Simulating...";
+        status.loader = true;
+      }
+      return status;
     }
   },
   watch: {

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -1,377 +1,466 @@
 <template>
-  <div>
-    <v-layout>
-      <v-autocomplete-extended
-        class="mr-2"
-        label="Experiment"
-        :items="experiments"
-        v-model="cardExperiment"
-        autoselectOnlyOption
-        item-text="name"
-        item-value="id"
-        placeholder="Choose the experiment you wish to simulate..."
-        return-object
-      ></v-autocomplete-extended>
+  <v-dialog v-model="showDialog" width="1200">
+    <v-card class="pa-2">
+      <v-form>
+        <v-container>
+          <p class="headline">Modify data-driven simulation</p>
 
-      <v-autocomplete-extended
-        class="ml-2 mr-2"
-        label="Conditions"
-        :items="conditions"
-        v-model="selectedCondition"
-        autoselectOnlyOption
-        :loading="isLoadingConditions"
-        :disabled="conditions === []"
-        item-text="name"
-        item-value="id"
-        placeholder="Choose the experimental conditions you wish to simulate..."
-        return-object
-      ></v-autocomplete-extended>
+          <v-layout wrap>
+            <v-flex xs12 md3>
+              <v-text-field
+                label="Card name"
+                v-model="cardName"
+                required
+              ></v-text-field>
+            </v-flex>
+            <v-flex xs12 md3>
+              <v-select-extended
+                label="Organism"
+                :items="organisms"
+                v-model="cardOrganism"
+                autoselectOnlyOption
+                item-text="name"
+                item-value="id"
+                :hint="modificationsHint"
+                persistent-hint
+                :rules="[v => !!v || 'Please choose the organism.']"
+                return-object
+                @change="onOrganismChange"
+              ></v-select-extended>
+            </v-flex>
+            <v-flex xs12 md3>
+              <v-select-extended
+                label="Model"
+                :items="modelsByOrganism"
+                v-model="cardModel"
+                autoselectOnlyOption
+                item-text="name"
+                item-value="id"
+                :hint="modificationsHint"
+                persistent-hint
+                :rules="[v => !!v || 'Please choose the metabolic model.']"
+                return-object
+                @change="onModelChange"
+              ></v-select-extended>
+            </v-flex>
+            <v-flex xs12 md3>
+              <v-select-extended
+                label="Method"
+                :items="methods"
+                v-model="cardMethod"
+                autoselectOnlyOption
+                item-text="name"
+                item-value="id"
+                prepend-icon="help"
+                @click:prepend="$emit('open-method-help-dialog')"
+                @change="$emit('simulate-card')"
+              ></v-select-extended>
+            </v-flex>
+          </v-layout>
 
-      <v-autocomplete-extended
-        class="ml-2"
-        label="Sample"
-        :items="samples"
-        v-model="cardSample"
-        autoselectOnlyOption
-        :loading="isLoadingConditionData"
-        :disabled="samples === []"
-        item-text="start_time"
-        item-value="id"
-        placeholder="Choose the sample you wish to simulate..."
-        return-object
-      ></v-autocomplete-extended>
-    </v-layout>
+          <v-layout>
+            <v-autocomplete-extended
+              class="mr-2"
+              label="Experiment"
+              :items="experiments"
+              v-model="cardExperiment"
+              autoselectOnlyOption
+              item-text="name"
+              item-value="id"
+              placeholder="Choose the experiment you wish to simulate..."
+              return-object
+            ></v-autocomplete-extended>
 
-    <span
-      v-if="isModifyingModel"
-      class="subheading font-weight-thin text-sm-center mb-2"
-    >
-      We are currently figuring out how to enrich the metabolic model with the
-      experimental data. This takes a few seconds, so please sit tight.
-      Meanwhile, feel free to inspect the data below.
-    </span>
-    <v-progress-linear
-      :indeterminate="true"
-      v-if="isModifyingModel"
-    ></v-progress-linear>
+            <v-autocomplete-extended
+              class="ml-2 mr-2"
+              label="Conditions"
+              :items="conditions"
+              v-model="selectedCondition"
+              autoselectOnlyOption
+              :loading="isLoadingConditions"
+              :disabled="conditions === []"
+              item-text="name"
+              item-value="id"
+              placeholder="Choose the experimental conditions you wish to simulate..."
+              return-object
+            ></v-autocomplete-extended>
 
-    <div v-if="organismMismatch" class="mb-2">
-      <v-alert :value="true" type="warning">
-        You are applying experimental data for the strain
-        <em>{{ conditionOrganism.name }}</em> to a model based on a different
-        organism (<em>{{ card.organism.name }}</em
-        >). Some data points may not apply succesfully.
-      </v-alert>
-    </div>
+            <v-autocomplete-extended
+              class="ml-2"
+              label="Sample"
+              :items="samples"
+              v-model="cardSample"
+              autoselectOnlyOption
+              :loading="isLoadingConditionData"
+              :disabled="samples === []"
+              item-text="start_time"
+              item-value="id"
+              placeholder="Choose the sample you wish to simulate..."
+              return-object
+            ></v-autocomplete-extended>
+          </v-layout>
 
-    <v-layout v-if="card.conditionData && card.sample" column>
-      <v-flex mb-1>
-        <v-card>
-          <v-subheader>Strain {{ card.conditionData.strain.name }}</v-subheader>
-          <v-card-text v-if="card.conditionData.strain.genotype">
-            <code class="px-2">{{ card.conditionData.strain.genotype }}</code>
-            <p class="mt-2">
-              The genotype above is described in
-              <a href="https://gnomic.readthedocs.io">gnomic</a> syntax, a
-              grammar to represent genotypes and phenotypes developed at DTU
-              Biosustain.
-            </p>
-          </v-card-text>
-          <v-card-text v-else>
-            There are no genotype modifications in this strain.
-          </v-card-text>
-        </v-card>
-      </v-flex>
-      <v-flex mb-1>
-        <v-card>
-          <v-subheader>Medium {{ card.conditionData.medium.name }}</v-subheader>
-          <v-data-table
-            :headers="mediumHeaders"
-            :items="card.conditionData.medium.compounds"
-            class="elevation-1"
+          <span
+            v-if="isModifyingModel"
+            class="subheading font-weight-thin text-sm-center mb-2"
           >
-            <template v-slot:items="{ item: compound }">
-              <td>{{ compound.compound_name }}</td>
-              <td>
-                <CompoundLink
-                  :identifier="compound.compound_identifier"
-                  :namespace="compound.compound_namespace"
-                />
-              </td>
-              <td>
-                <span v-if="compound.mass_concentration">
-                  {{ compound.mass_concentration }} <em>mmol/l</em>
-                </span>
-                <span v-else>Unspecified</span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
+            We are currently figuring out how to enrich the metabolic model with
+            the experimental data. This takes a few seconds, so please sit
+            tight. Meanwhile, feel free to inspect the data below.
+          </span>
+          <v-progress-linear
+            :indeterminate="true"
+            v-if="isModifyingModel"
+          ></v-progress-linear>
 
-      <v-flex mb-1 v-if="card.sample.fluxomics.length > 0">
-        <v-card>
-          <v-subheader>Fluxomics</v-subheader>
-          <v-data-table
-            :headers="fluxomicsHeaders"
-            :items="card.sample.fluxomics"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: reaction }">
-              <td>{{ reaction.reaction_name }}</td>
-              <td>
-                <ReactionLink
-                  :identifier="reaction.reaction_identifier"
-                  :namespace="reaction.reaction_namespace"
-                />
-              </td>
-              <td>
-                {{ reaction.measurement }}
-                <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
-              </td>
-              <td>
-                <span v-if="reaction.uncertainty">
-                  {{ reaction.uncertainty }}
-                  <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
+          <div v-if="organismMismatch" class="mb-2">
+            <v-alert :value="true" type="warning">
+              You are applying experimental data for the strain
+              <em>{{ conditionOrganism.name }}</em> to a model based on a
+              different organism (<em>{{ card.organism.name }}</em
+              >). Some data points may not apply succesfully.
+            </v-alert>
+          </div>
 
-      <v-flex mb-1 v-if="card.sample.metabolomics.length > 0">
-        <v-card>
-          <v-subheader>Metabolomics</v-subheader>
-          <v-data-table
-            :headers="metabolomicsHeaders"
-            :items="card.sample.metabolomics"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: metabolite }">
-              <td>{{ metabolite.compound_name }}</td>
-              <td>
-                <CompoundLink
-                  :identifier="metabolite.compound_identifier"
-                  :namespace="metabolite.compound_namespace"
-                />
-              </td>
-              <td>
-                {{ metabolite.measurement }}
-                <em>mmol/l</em>
-              </td>
-              <td>
-                <span v-if="metabolite.uncertainty">
-                  {{ metabolite.uncertainty }}
-                  <em>mmol/l</em>
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
-
-      <v-flex mb-1 v-if="card.sample.proteomics.length > 0">
-        <v-card>
-          <v-subheader>Proteomics</v-subheader>
-          <v-data-table
-            :headers="proteomicsHeaders"
-            :items="card.sample.proteomics"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: protein }">
-              <td>{{ protein.name }}</td>
-              <td>
-                <a
-                  :href="
-                    `https://www.uniprot.org/uniprot/${protein.identifier}`
-                  "
-                  target="_blank"
-                  >{{ protein.identifier }}</a
+          <v-layout v-if="card.conditionData && card.sample" column>
+            <v-flex mb-1>
+              <v-card>
+                <v-subheader
+                  >Strain {{ card.conditionData.strain.name }}</v-subheader
                 >
-              </td>
-              <td>
-                {{ protein.gene }}
-              </td>
-              <td>
-                {{ protein.measurement }}
-                <em>mmol/l</em>
-              </td>
-              <td>
-                <span v-if="protein.uncertainty">
-                  {{ protein.uncertainty }}
-                  <em>mmol/l</em>
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
-
-      <v-flex mb-1 v-if="card.sample.uptake_secretion_rates.length > 0">
-        <v-card>
-          <v-subheader>Uptake secretion rates</v-subheader>
-          <v-data-table
-            :headers="uptakeSecretionRatesHeaders"
-            :items="card.sample.uptake_secretion_rates"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: rate }">
-              <td>{{ rate.compound_name }}</td>
-              <td>
-                <CompoundLink
-                  :identifier="rate.compound_identifier"
-                  :namespace="rate.compound_namespace"
-                />
-              </td>
-              <td>
-                {{ rate.measurement }}
-                <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
-              </td>
-              <td>
-                <span v-if="rate.uncertainty">
-                  {{ rate.uncertainty }}
-                  <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
-
-      <v-flex mb-1 v-if="card.sample.molar_yields.length > 0">
-        <v-card>
-          <v-subheader>Molar yields</v-subheader>
-          <v-data-table
-            :headers="molarYieldsHeaders"
-            :items="card.sample.molar_yields"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: molarYield }">
-              <td>{{ molarYield.product_name }}</td>
-              <td>
-                <CompoundLink
-                  :identifier="molarYield.product_identifier"
-                  :namespace="molarYield.product_namespace"
-                />
-              </td>
-              <td>{{ molarYield.substrate_name }}</td>
-              <td>
-                <CompoundLink
-                  :identifier="molarYield.substrate_identifier"
-                  :namespace="molarYield.substrate_namespace"
-                />
-              </td>
-              <td>
-                {{ molarYield.measurement }}
-                <em
-                  >mmol-{{ molarYield.product_name }} / mmol-{{
-                    molarYield.substrate_name
-                  }}</em
+                <v-card-text v-if="card.conditionData.strain.genotype">
+                  <code class="px-2">{{
+                    card.conditionData.strain.genotype
+                  }}</code>
+                  <p class="mt-2">
+                    The genotype above is described in
+                    <a href="https://gnomic.readthedocs.io">gnomic</a> syntax, a
+                    grammar to represent genotypes and phenotypes developed at
+                    DTU Biosustain.
+                  </p>
+                </v-card-text>
+                <v-card-text v-else>
+                  There are no genotype modifications in this strain.
+                </v-card-text>
+              </v-card>
+            </v-flex>
+            <v-flex mb-1>
+              <v-card>
+                <v-subheader
+                  >Medium {{ card.conditionData.medium.name }}</v-subheader
                 >
-              </td>
-              <td>
-                <span v-if="molarYield.uncertainty">
-                  {{ molarYield.uncertainty }}
-                  <em
-                    >mmol-{{ molarYield.product_name }} / mmol-{{
-                      molarYield.substrate_name
-                    }}</em
-                  >
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
+                <v-data-table
+                  :headers="mediumHeaders"
+                  :items="card.conditionData.medium.compounds"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: compound }">
+                    <td>{{ compound.compound_name }}</td>
+                    <td>
+                      <CompoundLink
+                        :identifier="compound.compound_identifier"
+                        :namespace="compound.compound_namespace"
+                      />
+                    </td>
+                    <td>
+                      <span v-if="compound.mass_concentration">
+                        {{ compound.mass_concentration }} <em>mmol/l</em>
+                      </span>
+                      <span v-else>Unspecified</span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
 
-      <v-flex mb-1 v-if="card.sample.growth_rate">
-        <v-card>
-          <v-subheader>Growth rate</v-subheader>
-          <v-data-table
-            :headers="growthRateHeaders"
-            :items="[card.sample.growth_rate]"
-            class="elevation-1"
-          >
-            <template v-slot:items="{ item: growthRate }">
-              <td>
-                {{ growthRate.measurement }}
-                <em>h<sup>-1</sup></em>
-              </td>
-              <td>
-                <span v-if="growthRate.uncertainty">
-                  {{ growthRate.uncertainty }}
-                  <em>h<sup>-1</sup></em>
-                </span>
-                <span v-else>
-                  No uncertainty
-                </span>
-              </td>
-            </template>
-          </v-data-table>
-        </v-card>
-      </v-flex>
-    </v-layout>
+            <v-flex mb-1 v-if="card.sample.fluxomics.length > 0">
+              <v-card>
+                <v-subheader>Fluxomics</v-subheader>
+                <v-data-table
+                  :headers="fluxomicsHeaders"
+                  :items="card.sample.fluxomics"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: reaction }">
+                    <td>{{ reaction.reaction_name }}</td>
+                    <td>
+                      <ReactionLink
+                        :identifier="reaction.reaction_identifier"
+                        :namespace="reaction.reaction_namespace"
+                      />
+                    </td>
+                    <td>
+                      {{ reaction.measurement }}
+                      <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                    </td>
+                    <td>
+                      <span v-if="reaction.uncertainty">
+                        {{ reaction.uncertainty }}
+                        <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
 
-    <ModificationsTable
-      v-if="modifications.length > 0"
-      :modifications="modifications"
-      :readonly="true"
-    />
+            <v-flex mb-1 v-if="card.sample.metabolomics.length > 0">
+              <v-card>
+                <v-subheader>Metabolomics</v-subheader>
+                <v-data-table
+                  :headers="metabolomicsHeaders"
+                  :items="card.sample.metabolomics"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: metabolite }">
+                    <td>{{ metabolite.compound_name }}</td>
+                    <td>
+                      <CompoundLink
+                        :identifier="metabolite.compound_identifier"
+                        :namespace="metabolite.compound_namespace"
+                      />
+                    </td>
+                    <td>
+                      {{ metabolite.measurement }}
+                      <em>mmol/l</em>
+                    </td>
+                    <td>
+                      <span v-if="metabolite.uncertainty">
+                        {{ metabolite.uncertainty }}
+                        <em>mmol/l</em>
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
 
-    <v-expansion-panel v-if="card.sampleWarnings.length" class="mt-2">
-      <v-expansion-panel-content>
-        <template v-slot:header>
-          <div>
-            <v-badge color="warning">
-              <template v-slot:badge
-                >{{ card.sampleWarnings.length }}
+            <v-flex mb-1 v-if="card.sample.proteomics.length > 0">
+              <v-card>
+                <v-subheader>Proteomics</v-subheader>
+                <v-data-table
+                  :headers="proteomicsHeaders"
+                  :items="card.sample.proteomics"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: protein }">
+                    <td>{{ protein.name }}</td>
+                    <td>
+                      <a
+                        :href="
+                          `https://www.uniprot.org/uniprot/${protein.identifier}`
+                        "
+                        target="_blank"
+                        >{{ protein.identifier }}</a
+                      >
+                    </td>
+                    <td>
+                      {{ protein.gene }}
+                    </td>
+                    <td>
+                      {{ protein.measurement }}
+                      <em>mmol/l</em>
+                    </td>
+                    <td>
+                      <span v-if="protein.uncertainty">
+                        {{ protein.uncertainty }}
+                        <em>mmol/l</em>
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
+
+            <v-flex mb-1 v-if="card.sample.uptake_secretion_rates.length > 0">
+              <v-card>
+                <v-subheader>Uptake secretion rates</v-subheader>
+                <v-data-table
+                  :headers="uptakeSecretionRatesHeaders"
+                  :items="card.sample.uptake_secretion_rates"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: rate }">
+                    <td>{{ rate.compound_name }}</td>
+                    <td>
+                      <CompoundLink
+                        :identifier="rate.compound_identifier"
+                        :namespace="rate.compound_namespace"
+                      />
+                    </td>
+                    <td>
+                      {{ rate.measurement }}
+                      <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                    </td>
+                    <td>
+                      <span v-if="rate.uncertainty">
+                        {{ rate.uncertainty }}
+                        <em>mmol gDW<sup>-1</sup> h<sup>-1</sup></em>
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
+
+            <v-flex mb-1 v-if="card.sample.molar_yields.length > 0">
+              <v-card>
+                <v-subheader>Molar yields</v-subheader>
+                <v-data-table
+                  :headers="molarYieldsHeaders"
+                  :items="card.sample.molar_yields"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: molarYield }">
+                    <td>{{ molarYield.product_name }}</td>
+                    <td>
+                      <CompoundLink
+                        :identifier="molarYield.product_identifier"
+                        :namespace="molarYield.product_namespace"
+                      />
+                    </td>
+                    <td>{{ molarYield.substrate_name }}</td>
+                    <td>
+                      <CompoundLink
+                        :identifier="molarYield.substrate_identifier"
+                        :namespace="molarYield.substrate_namespace"
+                      />
+                    </td>
+                    <td>
+                      {{ molarYield.measurement }}
+                      <em
+                        >mmol-{{ molarYield.product_name }} / mmol-{{
+                          molarYield.substrate_name
+                        }}</em
+                      >
+                    </td>
+                    <td>
+                      <span v-if="molarYield.uncertainty">
+                        {{ molarYield.uncertainty }}
+                        <em
+                          >mmol-{{ molarYield.product_name }} / mmol-{{
+                            molarYield.substrate_name
+                          }}</em
+                        >
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
+
+            <v-flex mb-1 v-if="card.sample.growth_rate">
+              <v-card>
+                <v-subheader>Growth rate</v-subheader>
+                <v-data-table
+                  :headers="growthRateHeaders"
+                  :items="[card.sample.growth_rate]"
+                  class="elevation-1"
+                >
+                  <template v-slot:items="{ item: growthRate }">
+                    <td>
+                      {{ growthRate.measurement }}
+                      <em>h<sup>-1</sup></em>
+                    </td>
+                    <td>
+                      <span v-if="growthRate.uncertainty">
+                        {{ growthRate.uncertainty }}
+                        <em>h<sup>-1</sup></em>
+                      </span>
+                      <span v-else>
+                        No uncertainty
+                      </span>
+                    </td>
+                  </template>
+                </v-data-table>
+              </v-card>
+            </v-flex>
+          </v-layout>
+
+          <ModificationsTable
+            v-if="modifications.length > 0"
+            :modifications="modifications"
+            :readonly="true"
+          />
+
+          <v-expansion-panel v-if="card.sampleWarnings.length" class="mt-2">
+            <v-expansion-panel-content>
+              <template v-slot:header>
+                <div>
+                  <v-badge color="warning">
+                    <template v-slot:badge
+                      >{{ card.sampleWarnings.length }}
+                    </template>
+                    <span>Warnings</span>
+                  </v-badge>
+                </div>
               </template>
-              <span>Warnings</span>
-            </v-badge>
-          </div>
-        </template>
-        <div v-for="warning in card.sampleWarnings" :key="warning" class="mt-2">
-          <v-alert :value="true" type="warning">
-            {{ warning }}
-          </v-alert>
-        </div>
-      </v-expansion-panel-content>
-    </v-expansion-panel>
+              <div
+                v-for="warning in card.sampleWarnings"
+                :key="warning"
+                class="mt-2"
+              >
+                <v-alert :value="true" type="warning">
+                  {{ warning }}
+                </v-alert>
+              </div>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
 
-    <v-expansion-panel v-if="card.sampleErrors.length" class="mt-2">
-      <v-expansion-panel-content>
-        <template v-slot:header>
-          <div>
-            <v-badge color="error">
-              <template v-slot:badge>{{ card.sampleErrors.length }} </template>
-              <span>Errors</span>
-            </v-badge>
-          </div>
-        </template>
-        <div v-for="error in card.sampleErrors" :key="error" class="mt-2">
-          <v-alert :value="true" type="error">
-            {{ error }}
-          </v-alert>
-        </div>
-      </v-expansion-panel-content>
-    </v-expansion-panel>
-  </div>
+          <v-expansion-panel v-if="card.sampleErrors.length" class="mt-2">
+            <v-expansion-panel-content>
+              <template v-slot:header>
+                <div>
+                  <v-badge color="error">
+                    <template v-slot:badge
+                      >{{ card.sampleErrors.length }}
+                    </template>
+                    <span>Errors</span>
+                  </v-badge>
+                </div>
+              </template>
+              <div v-for="error in card.sampleErrors" :key="error" class="mt-2">
+                <v-alert :value="true" type="error">
+                  {{ error }}
+                </v-alert>
+              </div>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-container>
+      </v-form>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-progress-circular
+          v-if="card.isSimulating"
+          indeterminate
+          size="12"
+          :width="1"
+        ></v-progress-circular>
+        <span v-if="card.isSimulating" class="mx-2">
+          <em>Simulating...</em>
+        </span>
+        <v-btn color="primary" @click="showDialog = false">
+          Close
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script lang="ts">
@@ -384,6 +473,7 @@ import ReactionLink from "@/components/ReactionLink.vue";
 import CompoundLink from "@/components/CompoundLink.vue";
 import { Metabolite } from "@/store/modules/interactiveMap";
 import { buildReactionString } from "@/utils/reaction";
+import { ModelItem } from "@/store/modules/models";
 
 export default Vue.extend({
   name: "CardDialogDataDriven",
@@ -392,8 +482,14 @@ export default Vue.extend({
     ReactionLink,
     CompoundLink
   },
-  props: ["card", "modifications"],
+  props: ["card", "modifications", "value"],
   data: () => ({
+    methods: [
+      { id: "fba", name: "Flux Balance Analysis (FBA)" },
+      { id: "pfba", name: "Parsimonious FBA" },
+      { id: "fva", name: "Flux Variability Analysis (FVA)" },
+      { id: "pfba-fva", name: "Parsimonious FVA" }
+    ],
     conditions: [],
     selectedCondition: null,
     conditionOrganism: null,
@@ -447,6 +543,24 @@ export default Vue.extend({
     ]
   }),
   computed: {
+    organisms() {
+      return this.$store.state.organisms.organisms;
+    },
+    modelsByOrganism() {
+      if (!this.card.organism) {
+        return [];
+      }
+      return this.$store.state.models.models.filter(model => {
+        return model.organism_id === this.card.organism.id;
+      });
+    },
+    modificationsHint() {
+      if (this.modifications.length > 0) {
+        return `Changing this will reset ${this.modifications.length} modifications`;
+      } else {
+        return null;
+      }
+    },
     experiments() {
       return this.$store.state.experiments.experiments;
     },
@@ -461,6 +575,54 @@ export default Vue.extend({
         return false;
       }
       return this.card.organism.id != this.conditionOrganism.id;
+    },
+    cardName: {
+      get() {
+        return this.card.name;
+      },
+      set(name) {
+        this.updateCard({
+          uuid: this.card.uuid,
+          props: { name: name }
+        });
+        this.setModified({
+          uuid: this.card.uuid,
+          modified: true
+        });
+      }
+    },
+    cardOrganism: {
+      get() {
+        return this.card.organism;
+      },
+      set(organism) {
+        this.updateCard({
+          uuid: this.card.uuid,
+          props: { organism: organism }
+        });
+      }
+    },
+    cardModel: {
+      get() {
+        return this.model;
+      },
+      set(model: ModelItem) {
+        this.updateCard({
+          uuid: this.card.uuid,
+          props: { modelId: model.id }
+        });
+      }
+    },
+    cardMethod: {
+      get() {
+        return this.card.method;
+      },
+      set(method) {
+        this.updateCard({
+          uuid: this.card.uuid,
+          props: { method: method }
+        });
+      }
     },
     cardExperiment: {
       get() {
@@ -482,6 +644,14 @@ export default Vue.extend({
           uuid: this.card.uuid,
           props: { sample: sample }
         });
+      }
+    },
+    showDialog: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit("input", value);
       }
     }
   },
@@ -740,8 +910,49 @@ export default Vue.extend({
     }
   },
   methods: {
+    onOrganismChange() {
+      // When selected organism is updated, update the selected model
+      // correspondingly.
+      // TODO: Choose a default preferred model.
+      this.updateCard({
+        uuid: this.card.uuid,
+        props: { modelId: null }
+      });
+      // Since the model was updated, trigger `onModelChange` to make sure card
+      // modifications are reset.
+      this.onModelChange();
+    },
+    onModelChange() {
+      // Reset all modifications when the selected model changes.
+      // Note: We cannot simply watch `model` with `immediate: true`, because
+      // that would reset modifications when cards are added from other
+      // components, i.e., when visualizing jobs or designs.
+      this.updateCard({
+        uuid: this.card.uuid,
+        props: {
+          objective: {
+            reaction: null,
+            maximize: true
+          },
+          reactionDeletions: [],
+          reactionAdditions: [],
+          reactionKnockouts: [],
+          geneKnockouts: [],
+          editedBounds: [],
+          // Reset simulation results too
+          fluxes: null,
+          growthRate: null
+        }
+      });
+      this.setModified({
+        uuid: this.card.uuid,
+        modified: true
+      });
+      this.$emit("simulate-card");
+    },
     ...mapMutations({
-      updateCard: "interactiveMap/updateCard"
+      updateCard: "interactiveMap/updateCard",
+      setModified: "interactiveMap/setModified"
     })
   }
 });

--- a/src/views/InteractiveMap/CardDialogDataDriven.vue
+++ b/src/views/InteractiveMap/CardDialogDataDriven.vue
@@ -3,7 +3,57 @@
     <v-card class="pa-2">
       <v-form>
         <v-container>
-          <p class="headline">Modify data-driven simulation</p>
+          <v-layout row wrap>
+            <v-flex xs6>
+              <p class="headline">Modify data-driven simulation</p>
+            </v-flex>
+            <v-flex xs6>
+              <p class="text-xs-right subheading mb-0 mt-2 font-italic">
+                Simulation status:
+                <span v-if="card.solverStatus">
+                  <span v-if="card.solverStatus == 'optimal'">Successful</span>
+                  <span v-else-if="card.solverStatus == 'infeasible'"
+                    >Infeasible</span
+                  >
+                </span>
+                <span v-else-if="card.sampleErrors.length > 0"
+                  >Can not integrate data</span
+                >
+                <span v-else-if="card.hasSimulationError"
+                  >Error during simulation</span
+                >
+                <span v-else-if="!model && !card.sample"
+                  >Waiting for model and sample</span
+                >
+                <span v-else-if="!model">Waiting for a model</span>
+                <span v-else-if="!card.sample">Waiting for a sample</span>
+                <span v-else-if="isModifyingModel">
+                  Integrating data...
+                  <v-progress-circular
+                    indeterminate
+                    size="12"
+                    :width="1"
+                  ></v-progress-circular>
+                </span>
+                <span v-else-if="card.isSimulating">
+                  Simulating...
+                  <v-progress-circular
+                    indeterminate
+                    size="12"
+                    :width="1"
+                  ></v-progress-circular>
+                </span>
+                <span v-else>Unknown</span>
+              </p>
+            </v-flex>
+          </v-layout>
+
+          <v-progress-linear
+            v-if="card.isSimulating"
+            :indeterminate="true"
+            class="my-0"
+          ></v-progress-linear>
+          <div v-else style="height: 7px"></div>
 
           <v-layout wrap>
             <v-flex xs12 md3>
@@ -69,7 +119,6 @@
                 item-value="id"
                 :hint="modelHint"
                 persistent-hint
-                :rules="[v => !!v || 'Please choose the metabolic model.']"
                 return-object
                 @change="onModelChange"
               ></v-select-extended>
@@ -88,19 +137,6 @@
               ></v-select-extended>
             </v-flex>
           </v-layout>
-
-          <span
-            v-if="isModifyingModel"
-            class="subheading font-weight-thin text-sm-center mb-2"
-          >
-            We are currently figuring out how to enrich the metabolic model with
-            the experimental data. This takes a few seconds, so please sit
-            tight. Meanwhile, feel free to inspect the data below.
-          </span>
-          <v-progress-linear
-            :indeterminate="true"
-            v-if="isModifyingModel"
-          ></v-progress-linear>
 
           <v-layout v-if="card.conditionData && card.sample" column>
             <v-flex mb-1>


### PR DESCRIPTION
It looks like a big changeset, but most of the changes are in the second commit which simply moves the `CardDialogDataDriven` out of the parent component, `CardDialog`. Now it's reimplementing logic from the parent, which makes it easier to control when simulations happens etc.

[The issue](https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/912) is implemented in [the third commit](https://github.com/DD-DeCaF/caffeine-vue/pull/195/commits/cbc13dd4bd24e0f96f0c10e15d4789cc0e625e74) by removing the organism drop-down and now auto-selecting the organism based on the selected strain.

The last commit implements the status [I posted about here](https://biosustain.slack.com/archives/G8SBED3C3/p1574331459000700).