### PR TITLE
chore: pin vuetify v1.5.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13632,9 +13632,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "1.5.21",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.21.tgz",
-      "integrity": "sha512-x0F2mNoWMXVA2ntrmvfjJFU2elaq2WK1tD9wOBu447xUHdZqswziFD82pNtmWRy3TjEXsLj/ZNO8e5dZig+Iqg=="
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.14.tgz",
+      "integrity": "sha512-7iM+TfghR/wu/Gl+k37lKr0N8Ddr6SxzqHtoK1dIyHgCH6SJRkpaXPw2MC5/FsAg9aUDJbYNWrzSeu5eHw+Q/w=="
     },
     "vuetify-loader": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vue-analytics": "^5.17.4",
     "vue-moment": "^4.0.0",
     "vue-router": "^3.1.3",
-    "vuetify": "^1.5.21",
+    "vuetify": "1.5.14",
     "vuex": "^3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest minor version breaks html compatibility for hints.