### PR TITLE
Show invalid rows first

### DIFF
--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -1028,6 +1028,9 @@
               class="mt-3"
               >Add row</v-btn
             >
+            <v-btn color="primary" small @click="showInvalidRows()" class="mt-3"
+              >Show invalid rows first</v-btn
+            >
           </v-card>
         </v-flex>
 
@@ -2123,6 +2126,24 @@ export default Vue.extend({
     },
     onMeasurementClear(index, table, property) {
       table.items[index][property] = null;
+    },
+    showInvalidRows() {
+      const table = this.tables[this.selectedTableKey];
+      const keys = Object.keys(table.rules);
+      const validItems: any[] = [];
+      const invalidItems: any[] = [];
+      table.items.forEach(item => {
+        if (
+          keys.every(key =>
+            table.rules[key](item).every(valid => typeof valid === "boolean")
+          )
+        ) {
+          validItems.push(item);
+        } else {
+          invalidItems.push(item);
+        }
+      });
+      table.items = [...invalidItems, ...validItems];
     }
   }
 });

--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -1168,7 +1168,8 @@ import {
   unzip,
   keyBy,
   findKey,
-  isEmpty
+  isEmpty,
+  sortBy
 } from "lodash";
 import * as settings from "@/utils/settings";
 import { mapMnxReactionToReaction } from "@/utils/reaction";
@@ -2132,18 +2133,12 @@ export default Vue.extend({
       const keys = Object.keys(table.rules);
       const validItems: any[] = [];
       const invalidItems: any[] = [];
-      table.items.forEach(item => {
-        if (
-          keys.every(key =>
-            table.rules[key](item).every(valid => typeof valid === "boolean")
-          )
-        ) {
-          validItems.push(item);
-        } else {
-          invalidItems.push(item);
-        }
+      table.items = sortBy(table.items, item => {
+        const isValid = keys.every(key =>
+          table.rules[key](item).every(valid => typeof valid === "boolean")
+        );
+        return isValid ? 1 : -1;
       });
-      table.items = [...invalidItems, ...validItems];
     }
   }
 });

--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -159,13 +159,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('conditions')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -273,13 +266,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('samples')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -396,13 +382,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('fluxomics')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -537,13 +516,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('metabolomics')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -658,13 +630,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('proteomics')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -799,13 +764,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('uptakeSecretion')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -972,13 +930,6 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('molarYields')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
 
@@ -1068,15 +1019,15 @@
                     </Var>
                   </template>
                 </v-data-table>
-                <v-btn
-                  color="primary"
-                  small
-                  @click="addRow('growth')"
-                  class="mt-3"
-                  >Add row</v-btn
-                >
               </div>
             </v-form-extended>
+            <v-btn
+              color="primary"
+              small
+              @click="addRow(selectedTableKey)"
+              class="mt-3"
+              >Add row</v-btn
+            >
           </v-card>
         </v-flex>
 

--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -30,6 +30,7 @@
                   :items="tables.conditions.items"
                   :pagination.sync="tables.conditions.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -170,6 +171,7 @@
                   :items="tables.samples.items"
                   :pagination.sync="tables.samples.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -277,6 +279,7 @@
                   :items="tables.fluxomics.items"
                   :pagination.sync="tables.fluxomics.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -393,6 +396,7 @@
                   :items="tables.metabolomics.items"
                   :pagination.sync="tables.metabolomics.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -527,6 +531,7 @@
                   :items="tables.proteomics.items"
                   :pagination.sync="tables.proteomics.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -641,6 +646,7 @@
                   :items="tables.uptakeSecretion.items"
                   :pagination.sync="tables.uptakeSecretion.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -775,6 +781,7 @@
                   :items="tables.molarYields.items"
                   :pagination.sync="tables.molarYields.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -941,6 +948,7 @@
                   :items="tables.growth.items"
                   :pagination.sync="tables.growth.pagination"
                   :rows-per-page-items="[10, 25]"
+                  hide-actions
                   disable-initial-sort
                 >
                   <template
@@ -1025,12 +1033,19 @@
               color="primary"
               small
               @click="addRow(selectedTableKey)"
-              class="mt-3"
+              class="mt-4"
               >Add row</v-btn
             >
-            <v-btn color="primary" small @click="showInvalidRows()" class="mt-3"
+            <v-btn color="primary" small @click="showInvalidRows()" class="mt-4"
               >Show invalid rows first</v-btn
             >
+            <div class="text-xs-center mt-4">
+              <v-pagination
+                v-model="tables[selectedTableKey].pagination.page"
+                :length="calculatePaginatorLength()"
+                :totalVisible="7"
+              ></v-pagination>
+            </div>
           </v-card>
         </v-flex>
 
@@ -2139,6 +2154,18 @@ export default Vue.extend({
         );
         return isValid ? 1 : -1;
       });
+    },
+    calculatePaginatorLength() {
+      if (
+        this.tables[this.selectedTableKey].pagination.rowsPerPage == null ||
+        this.tables[this.selectedTableKey].items.length === 0
+      ) {
+        return 0;
+      }
+      return Math.ceil(
+        this.tables[this.selectedTableKey].items.length /
+          this.tables[this.selectedTableKey].pagination.rowsPerPage
+      );
     }
   }
 });

--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -2146,8 +2146,6 @@ export default Vue.extend({
     showInvalidRows() {
       const table = this.tables[this.selectedTableKey];
       const keys = Object.keys(table.rules);
-      const validItems: any[] = [];
-      const invalidItems: any[] = [];
       table.items = sortBy(table.items, item => {
         const isValid = keys.every(key =>
           table.rules[key](item).every(valid => typeof valid === "boolean")


### PR DESCRIPTION
Closes https://github.com/DD-DeCaF/scrum/issues/1154

Proposed solution: to add button that sorts array to display invalid rows first.

Issues with initial idea to add a checkbox to filter the array:
1. If checkbox is selected, the moment user changes the row to be valid, that row will disappear, that might be confusing. Keeping that row displayed is also not a perfect UX solution considering that checkbox "Show only invalid rows" is selected
2. Possibility to paste data will be disabled

Update:
Pagination was changed, now user can navigate to first or last page.