### PR TITLE
feat: only select recommended protein name

### DIFF
--- a/src/components/NewExperiment.vue
+++ b/src/components/NewExperiment.vue
@@ -1644,9 +1644,16 @@ export default Vue.extend({
         );
         return strs.map(str => {
           if (str in parsedResponse) {
+            // The protein name field includes both recommended name, and
+            // alternative names in parentheses. Use only the recommended name.
+            let proteinName = parsedResponse[str]["Protein names"] || "Unknown";
+            const index = proteinName.indexOf("(");
+            if (index !== -1) {
+              proteinName = proteinName.substring(0, index).trim();
+            }
             return {
               identifier: parsedResponse[str]["Entry name"] || "Unknown",
-              name: parsedResponse[str]["Protein names"] || "Unknown",
+              name: proteinName,
               gene: parsedResponse[str]["Gene names  (primary )"] || "Unknown",
               uniprotId: str
             };


### PR DESCRIPTION
The batch endpoint returns all the protein names but we only care about the recommended one. Before:

![image](https://user-images.githubusercontent.com/64745/69531299-f1c38600-0f73-11ea-96c9-9a0f28e4725d.png)

After:

![image](https://user-images.githubusercontent.com/64745/69531309-f5570d00-0f73-11ea-9b62-bf5479e7a407.png)
