### PR TITLE
fix: gene matching when showing proteomics

### DIFF
--- a/src/views/InteractiveMap/Escher.vue
+++ b/src/views/InteractiveMap/Escher.vue
@@ -489,8 +489,7 @@ export default Vue.extend({
               );
               proteomicsGeneIds.forEach(proteomicsGeneId => {
                 if (proteomicsGeneId in modelGeneIdsWithNames) {
-                  const geneName = modelGeneIdsWithNames[proteomicsGeneId].name;
-                  geneData[geneName] = proteomicsItem.measurement;
+                  geneData[proteomicsGeneId] = proteomicsItem.measurement;
                 }
               });
             });


### PR DESCRIPTION
some models (for instance ecModels) don't have gene names, so it's safer/simpler to match to their gene ids.

**Note:** The visualization still fails for data in scientific notation (due to low values), but that is an Escher bug that will be addressed separately.