### PR TITLE
Added an Icon with a tooltip as growth rate alert to the Card component

### DIFF
--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -181,20 +181,6 @@
       <v-container fluid class="pa-0">
         <v-layout wrap>
           <v-flex>Growth rate:</v-flex>
-          <v-flex>
-            <div v-if="card.growthRate !== null">
-              <v-tooltip v-if="card.growthRate <= 0.00001" bottom>
-                <template v-slot:activator="{ on }">
-                  <v-icon color="warning" dark v-on="on">error</v-icon>
-                </template>
-                <span>
-                  You are simulating with proteomics data but without setting
-                  any growth rate. <br />Consider adding a growth rate to your
-                  experiment to avoid unreasonably low growth rate predictions.
-                </span>
-              </v-tooltip>
-            </div>
-          </v-flex>
           <v-flex class="text-xs-right">
             <div v-if="!card.isSimulating">
               <span
@@ -205,6 +191,25 @@
                 <em>h<sup>-1</sup></em>
               </span>
               <span v-else>N/A</span>
+              <span v-if="card.growthRate === null">
+                <v-tooltip
+                  v-if="
+                    card.type == 'DataDriven' &&
+                      card.sample.proteomics.length > 0
+                  "
+                  bottom
+                >
+                  <template v-slot:activator="{ on }">
+                    <v-icon color="warning" dark v-on="on">error</v-icon>
+                  </template>
+                  <span>
+                    You are simulating with proteomics data without setting a
+                    growth rate. <br />Consider adding a growth rate to your
+                    experiment to avoid unreasonably low growth rate
+                    predictions.
+                  </span>
+                </v-tooltip>
+              </span>
             </div>
             <div v-else>
               <v-progress-circular

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -181,6 +181,20 @@
       <v-container fluid class="pa-0">
         <v-layout wrap>
           <v-flex>Growth rate:</v-flex>
+          <v-flex>
+            <div v-if="card.growthRate !== null">
+              <v-tooltip v-if="card.growthRate <= 0.00001" bottom>
+                <template v-slot:activator="{ on }">
+                  <v-icon color="warning" dark v-on="on">error</v-icon>
+                </template>
+                <span>
+                  You are simulating with proteomics data but without setting
+                  any growth rate. <br />Consider adding a growth rate to your
+                  experiment to avoid unreasonably low growth rate predictions.
+                </span>
+              </v-tooltip>
+            </div>
+          </v-flex>
           <v-flex class="text-xs-right">
             <div v-if="!card.isSimulating">
               <span

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -191,14 +191,17 @@
                 <em>h<sup>-1</sup></em>
               </span>
               <span v-else>N/A</span>
-              <span v-if="card.sample.growth_rate === null && model.ec_model">
-                <v-tooltip
-                  v-if="
+              <span
+                v-if="
+                  model &&
+                    model.ec_model &&
                     card.type == 'DataDriven' &&
-                      card.sample.proteomics.length > 0
-                  "
-                  bottom
-                >
+                    card.sample !== null &&
+                    card.sample.proteomics.length > 0 &&
+                    card.sample.growth_rate === null
+                "
+              >
+                <v-tooltip bottom>
                   <template v-slot:activator="{ on }">
                     <v-icon color="warning" dark v-on="on">error</v-icon>
                   </template>

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -191,7 +191,7 @@
                 <em>h<sup>-1</sup></em>
               </span>
               <span v-else>N/A</span>
-              <span v-if="card.growthRate === null">
+              <span v-if="card.sample.growth_rate === null && model.ec_model">
                 <v-tooltip
                   v-if="
                     card.type == 'DataDriven' &&


### PR DESCRIPTION
Closes https://github.com/DD-DeCaF/scrum/issues/1086

The value chosen from which it starts showing up is an arbitrary low value, maybe it should be more clearly defined? 

Here's how it looks in action: 
<img width="282" alt="grafik" src="https://user-images.githubusercontent.com/21173947/72819832-3c106d00-3c6e-11ea-8b77-90ac40a2291c.png">


Can whoever reads this also give me some feedback if I worked on this correctly, the way that the team would normally do this?