### PR TITLE
Enzyme usage slider

### DIFF
--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -537,7 +537,8 @@ export default Vue.extend({
       return (
         this.card.type == "DataDriven" &&
         this.card.sample &&
-        this.card.sample.proteomics.length > 0
+        this.card.sample.proteomics.length > 0 &&
+        this.model.ec_model
       );
     },
     enzymeUsageThreshold: {

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -191,25 +191,6 @@
                 <em>h<sup>-1</sup></em>
               </span>
               <span v-else>N/A</span>
-              <span v-if="card.growthRate === null">
-                <v-tooltip
-                  v-if="
-                    card.type == 'DataDriven' &&
-                      card.sample.proteomics.length > 0
-                  "
-                  bottom
-                >
-                  <template v-slot:activator="{ on }">
-                    <v-icon color="warning" dark v-on="on">error</v-icon>
-                  </template>
-                  <span>
-                    You are simulating with proteomics data without setting a
-                    growth rate. <br />Consider adding a growth rate to your
-                    experiment to avoid unreasonably low growth rate
-                    predictions.
-                  </span>
-                </v-tooltip>
-              </span>
             </div>
             <div v-else>
               <v-progress-circular

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -261,7 +261,11 @@
       </v-container>
 
       <!-- ecModels visualizing enzyme usage -->
-      <v-container v-if="showEnzymeUsageSlider" fluid class="pa-0">
+      <v-container
+        v-if="showEnzymeUsageSlider && model && model.ec_model"
+        fluid
+        class="pa-0"
+      >
         <v-layout row>
           <v-flex>
             Highlight reactions where enzyme usage is greater than or equal to
@@ -518,8 +522,7 @@ export default Vue.extend({
       return (
         this.card.type == "DataDriven" &&
         this.card.sample &&
-        this.card.sample.proteomics.length > 0 &&
-        this.model.ec_model
+        this.card.sample.proteomics.length > 0
       );
     },
     enzymeUsageThreshold: {

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -181,20 +181,6 @@
       <v-container fluid class="pa-0">
         <v-layout wrap>
           <v-flex>Growth rate:</v-flex>
-          <v-flex>
-            <div v-if="card.growthRate !== null">
-              <v-tooltip v-if="card.growthRate <= 0.00001" bottom>
-                <template v-slot:activator="{ on }">
-                  <v-icon color="warning" dark v-on="on">error</v-icon>
-                </template>
-                <span>
-                  You are simulating with proteomics data but without setting
-                  any growth rate. <br />Consider adding a growth rate to your
-                  experiment to avoid unreasonably low growth rate predictions.
-                </span>
-              </v-tooltip>
-            </div>
-          </v-flex>
           <v-flex class="text-xs-right">
             <div v-if="!card.isSimulating">
               <span
@@ -205,6 +191,25 @@
                 <em>h<sup>-1</sup></em>
               </span>
               <span v-else>N/A</span>
+              <span v-if="card.growthRate === null">
+                <v-tooltip
+                  v-if="
+                    card.type == 'DataDriven' &&
+                      card.sample.proteomics.length > 0
+                  "
+                  bottom
+                >
+                  <template v-slot:activator="{ on }">
+                    <v-icon color="warning" dark v-on="on">error</v-icon>
+                  </template>
+                  <span>
+                    You are simulating with proteomics data without setting a
+                    growth rate. <br />Consider adding a growth rate to your
+                    experiment to avoid unreasonably low growth rate
+                    predictions.
+                  </span>
+                </v-tooltip>
+              </span>
             </div>
             <div v-else>
               <v-progress-circular

--- a/src/views/InteractiveMap/Card.vue
+++ b/src/views/InteractiveMap/Card.vue
@@ -181,6 +181,20 @@
       <v-container fluid class="pa-0">
         <v-layout wrap>
           <v-flex>Growth rate:</v-flex>
+          <v-flex>
+            <div v-if="card.growthRate !== null">
+              <v-tooltip v-if="card.growthRate <= 0.00001" bottom>
+                <template v-slot:activator="{ on }">
+                  <v-icon color="warning" dark v-on="on">error</v-icon>
+                </template>
+                <span>
+                  You are simulating with proteomics data but without setting
+                  any growth rate. <br />Consider adding a growth rate to your
+                  experiment to avoid unreasonably low growth rate predictions.
+                </span>
+              </v-tooltip>
+            </div>
+          </v-flex>
           <v-flex class="text-xs-right">
             <div v-if="!card.isSimulating">
               <span


### PR DESCRIPTION
hides enzyme usage slider when a non-ec model is chosen but proteomics data is added, as well as when no proteomics data is provided on an ec model.