### PR TITLE
refactor: define RootState TypeScript interface

### DIFF
--- a/src/store/modules/designs.ts
+++ b/src/store/modules/designs.ts
@@ -23,12 +23,17 @@ export interface DesignItem {
   method: string;
 }
 
+export interface DesignsState {
+  designs: DesignItem[];
+  designsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    designs: [] as DesignItem[],
-    designsPromise: null as Promise<void> | null
-  },
+    designs: [],
+    designsPromise: null
+  } as DesignsState,
   mutations: {
     setDesigns(state, designs: DesignItem[]) {
       state.designs = designs;

--- a/src/store/modules/experiments.ts
+++ b/src/store/modules/experiments.ts
@@ -12,12 +12,17 @@ export interface ExperimentItem {
   updated: string;
 }
 
+export interface ExperimentsState {
+  experiments: ExperimentItem[];
+  experimentsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    experiments: [] as ExperimentItem[],
-    experimentsPromise: null as Promise<void> | null
-  },
+    experiments: [],
+    experimentsPromise: null
+  } as ExperimentsState,
   mutations: {
     setExperiments(state, experiments: ExperimentItem[]) {
       state.experiments = experiments;

--- a/src/store/modules/interactiveMap.ts
+++ b/src/store/modules/interactiveMap.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import he from "he";
 import * as settings from "@/utils/settings";
 import { OrganismItem } from "./organisms";
+import { MapItem } from "./maps";
 
 export interface Gene {
   id: string;
@@ -76,12 +77,17 @@ export interface Card {
   enzymeUsageThreshold: number;
 }
 
+export interface InteractiveMapState {
+  currentMapId: MapItem["id"] | null;
+  cards: Card[];
+}
+
 export default {
   namespaced: true,
   state: {
     currentMapId: null,
-    cards: [] as Card[]
-  },
+    cards: []
+  } as InteractiveMapState,
   mutations: {
     setCurrentMapId(state, currentMapId) {
       state.currentMapId = currentMapId;

--- a/src/store/modules/jobs.ts
+++ b/src/store/modules/jobs.ts
@@ -16,13 +16,19 @@ export interface JobItem {
   aerobic: boolean;
 }
 
+export interface JobsState {
+  jobs: JobItem[];
+  isPolling: boolean;
+  jobsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    jobs: [] as JobItem[],
+    jobs: [],
     isPolling: false,
-    jobsPromise: null as Promise<void> | null
-  },
+    jobsPromise: null
+  } as JobsState,
   mutations: {
     setJobs(state, jobs: JobItem[]) {
       state.jobs = jobs;

--- a/src/store/modules/maps.ts
+++ b/src/store/modules/maps.ts
@@ -11,12 +11,17 @@ export interface MapItem {
   project_id: number;
 }
 
+export interface MapState {
+  maps: MapItem[];
+  mapsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    maps: [] as MapItem[],
-    mapsPromise: null as Promise<void> | null
-  },
+    maps: [],
+    mapsPromise: null
+  } as MapState,
   mutations: {
     setMaps(state, maps: MapItem[]) {
       state.maps = maps;

--- a/src/store/modules/media.ts
+++ b/src/store/modules/media.ts
@@ -18,13 +18,19 @@ export interface MediumCompound {
   medium_id: number;
 }
 
+export interface MediaState {
+  media: MediumItem[];
+  mediaPromise: Promise<void> | null;
+  _compoundsPromise: Promise<MediumCompound[]> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    media: [] as MediumItem[],
-    mediaPromise: null as Promise<void> | null,
-    _compoundsPromise: null as Promise<MediumCompound[]> | null
-  },
+    media: [],
+    mediaPromise: null,
+    _compoundsPromise: null
+  } as MediaState,
   mutations: {
     setMedia(state, media: MediumItem[]) {
       state.media = media;

--- a/src/store/modules/models.ts
+++ b/src/store/modules/models.ts
@@ -17,6 +17,12 @@ export interface ModelItem {
   model_serialized?: object;
 }
 
+export interface ModelsState {
+  models: ModelItem[];
+  modelsPromise: Promise<void> | null;
+  fullModelPromises: Record<number, Promise<void>>;
+}
+
 // TODO (Moritz Beber): This mapping needs to be expanded to all organisms.
 // See https://github.com/DD-DeCaF/caffeine-vue/issues/41
 export const organism2ModelMapping = {
@@ -26,12 +32,12 @@ export const organism2ModelMapping = {
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    models: [] as ModelItem[],
-    modelsPromise: null as Promise<void> | null,
+    models: [],
+    modelsPromise: null,
     // `fullModelPromises` contains the promises to request the full model,
     // keyed by model id. See the `withFullModel` action.
-    fullModelPromises: {} as Record<number, Promise<void>>
-  },
+    fullModelPromises: {}
+  } as ModelsState,
   mutations: {
     setModels(state, models: ModelItem[]) {
       state.models = models;

--- a/src/store/modules/organisms.ts
+++ b/src/store/modules/organisms.ts
@@ -11,12 +11,17 @@ export interface OrganismItem {
   updated: string;
 }
 
+export interface OrganismsState {
+  organisms: OrganismItem[];
+  organismsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    organisms: [] as OrganismItem[],
-    organismsPromise: null as Promise<void> | null
-  },
+    organisms: [],
+    organismsPromise: null
+  } as OrganismsState,
   mutations: {
     setOrganisms(state, organisms: OrganismItem[]) {
       state.organisms = organisms;

--- a/src/store/modules/projects.ts
+++ b/src/store/modules/projects.ts
@@ -14,7 +14,7 @@ export interface ColoredProjectItem extends ProjectItem {
   color: string;
 }
 
-interface ProjectStore {
+export interface ProjectsState {
   projects: ColoredProjectItem[];
   activeProject: ColoredProjectItem | null | undefined;
   projectsPromise: Promise<void> | null;
@@ -41,7 +41,7 @@ export default vuexStoreModule({
     projects: [],
     activeProject: null,
     projectsPromise: null
-  } as ProjectStore,
+  } as ProjectsState,
   mutations: {
     setProjects(state, projects: ColoredProjectItem[]) {
       state.projects = projects;

--- a/src/store/modules/session.ts
+++ b/src/store/modules/session.ts
@@ -152,7 +152,7 @@ export interface CookieOption {
   canOptOut: boolean;
 }
 
-type SessionState = LinkedJWTAuthenticated & {
+export type SessionState = LinkedJWTAuthenticated & {
   cookieOptions: CookieOption[];
   consentError: null;
   consents: Consent[];

--- a/src/store/modules/strains.ts
+++ b/src/store/modules/strains.ts
@@ -14,12 +14,17 @@ export interface StrainItem {
   updated: string;
 }
 
+export interface StrainsState {
+  strains: StrainItem[];
+  strainsPromise: Promise<void> | null;
+}
+
 export default vuexStoreModule({
   namespaced: true,
   state: {
-    strains: [] as StrainItem[],
-    strainsPromise: null as Promise<void> | null
-  },
+    strains: [],
+    strainsPromise: null
+  } as StrainsState,
   mutations: {
     setStrains(state, strains: StrainItem[]) {
       state.strains = strains;

--- a/src/types/vuex.d.ts
+++ b/src/types/vuex.d.ts
@@ -1,0 +1,27 @@
+import { DesignsState } from "@/store//modules/designs";
+import { ExperimentsState } from "@/store/modules/experiments";
+import { InteractiveMapState } from "@/store/modules/interactiveMap";
+import { JobsState } from "@/store/modules/jobs";
+import { MapState } from "@/store/modules/maps";
+import { MediaState } from "@/store/modules/media";
+import { ModelsState } from "@/store/modules/models";
+import { OrganismsState } from "@/store/modules/organisms";
+import { ProjectsState } from "@/store/modules/projects";
+import { SessionState } from "@/store/modules/session";
+import { StrainsState } from "@/store/modules/strains";
+
+// Fix for when using rootState in a Vuex module, TypeScript doesn't know
+// about the other modules
+export type RootState = {
+  designs: DesignsState;
+  experiments: ExperimentsState;
+  interactiveMap: InteractiveMapState;
+  jobs: JobsState;
+  maps: MapState;
+  media: MediaState;
+  models: ModelsState;
+  organisms: OrganismsState;
+  projects: ProjectsState;
+  session: SessionState;
+  strains: StrainsState;
+};


### PR DESCRIPTION
The interface is necessary for using rootState inside store modules.
Otherwise the compiler complains.