### PR TITLE
Fix/cookies policy too strict

### DIFF
--- a/src/components/CookieConsent.vue
+++ b/src/components/CookieConsent.vue
@@ -37,8 +37,9 @@
             <router-link to="privacy-policy">Privacy policy</router-link>.
           </p>
           <p class="mb-0">
-            <small>
-              Note: Preferences cookies are necessary to hide this notification.
+            <small class="warning py-1 px-1 font-weight-bold">
+              Note: Preferences cookies are necessary to hide this notification
+              and remember login.
             </small>
           </p>
         </v-container>

--- a/src/store/modules/consents.ts
+++ b/src/store/modules/consents.ts
@@ -167,8 +167,9 @@ export default vuexStoreModule({
         message:
           "These cookies allow to remember choices you have made such as " +
           "what your user name and password are so you can automatically " +
-          "log in.<br/><br/>Note: Preferences cookies are necessary to " +
-          "remember which cookies you agreed to.",
+          "log in.<br/><br/><small class='warning py-1 px-1 font-weight-bold'" +
+          ">Note: Preferences cookies are necessary to hide cookies " +
+          "notification and remember login.</small>",
         default: false,
         canOptOut: true
       },

--- a/src/store/plugins/cookies.ts
+++ b/src/store/plugins/cookies.ts
@@ -9,26 +9,45 @@ import { Store } from "vuex";
  * on beforeunload.
  */
 export const cookiePlugin = (store: Store<any>) => {
+  const clearPreferencesCookies = () => {
+    // Do nothing if consents are not enabled
+    if (!store.state.consents.enableConsents) {
+      return;
+    }
+    // Sanity check - do nothing if preferences cookies accepted
+    if (
+      store.getters["consents/isConsentAccepted"]({
+        type: "cookie",
+        category: "preferences"
+      })
+    ) {
+      return;
+    }
+    ["jwt", "cookie:accepted", "consents"].forEach(k =>
+      localStorage.removeItem(k)
+    );
+  };
+  // Guard against assigning multiple on-event callbacks
+  let clearPrefFuncAssigned = false;
+
   store.subscribe(({ type, payload }, state) => {
-    const clearPreferencesCookies = () => {
-      // Do nothing if consents are not enabled
-      if (!store.state.consents.enableConsents) {
-        return;
-      }
-      ["jwt", "cookie:accepted", "consents"].forEach(k =>
-        localStorage.removeItem(k)
-      );
-    };
     if (type === "consents/setConsent") {
       if (payload.type === "cookie" && payload.category === "preferences") {
         if (store.getters["consents/isConsentAccepted"](payload)) {
           window.removeEventListener("beforeunload", clearPreferencesCookies);
+          clearPrefFuncAssigned = false;
         } else {
-          window.addEventListener("beforeunload", clearPreferencesCookies);
+          if (!clearPrefFuncAssigned) {
+            window.addEventListener("beforeunload", clearPreferencesCookies);
+            clearPrefFuncAssigned = true;
+          }
         }
       }
     } else if (type === "consents/clearConsents") {
-      window.addEventListener("beforeunload", clearPreferencesCookies);
+      if (!clearPrefFuncAssigned) {
+        window.addEventListener("beforeunload", clearPreferencesCookies);
+        clearPrefFuncAssigned = true;
+      }
     }
   });
 };

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -598,7 +598,7 @@ export default Vue.extend({
             category: category,
             message: message,
             status: this.cookies[category] ? "accepted" : "rejected",
-            source: "cookie_consent_banner"
+            source: "privacy_policy"
           });
         }
       );


### PR DESCRIPTION
Fixes issue when user is logged out in the case that:
1) User is initially logged out.
2) Before logging in they changed their cookie consents to reject preferences (e.g. by not ticking the preferences option in the cookie banner).
3) They log in.
4) They changed their preferences cookies to accepted as logged in.

This action should keep the user logged in, as they agreed to have their login token remembered.

The issue was with vanilla JS events. Event callback to clear localStorage on "beforeunload" was assigned multiple times, but removed only once, which meant that only one of callbacks was removed, but others still cleared the localStorage despite user's state permitting the storage.

Additionally made the warning stating the implications of rejecting preferences cookies more prominent.