### PR TITLE
Add medium fix

### DIFF
--- a/src/components/NewMedium.vue
+++ b/src/components/NewMedium.vue
@@ -210,6 +210,13 @@ export default Vue.extend({
           this.isMediumCreationSuccess = true;
           this.isDialogVisible = false;
         })
+        .then(() => {
+          // Refetch compounds from the warehouse in order to get updated state.
+          // We could update the store locally and make sure to add the returned
+          // IDs when POSTing the compounds - this is slightly slower for the
+          // user but a lot less complex to implement.
+          return this.$store.dispatch("media/fetchMediaCompounds");
+        })
         .catch(error => {
           this.$store.commit("setPostError", error);
         })

--- a/src/components/NewMedium.vue
+++ b/src/components/NewMedium.vue
@@ -223,7 +223,7 @@ export default Vue.extend({
             compound_identifier: compound.id,
             compound_name: compound.name,
             compound_namespace: compound.namespace,
-            mass_concentration: compound.mass_concentration,
+            mass_concentration: compound.mass_concentration || null,
             medium_id: mediumId
           };
           this.$store.commit("media/addCompound", payload);

--- a/src/components/NewMedium.vue
+++ b/src/components/NewMedium.vue
@@ -66,12 +66,6 @@
                         <v-flex xs3>
                           <v-number-field
                             v-model.number="compound.mass_concentration"
-                            :rules="[
-                              rules.conditionallyRequired(
-                                compound.mass_concentration,
-                                !!compound.id
-                              )
-                            ]"
                             name="mass"
                             label="Mass Concentration"
                             hint="mmol l <sup>-1</sup>"


### PR DESCRIPTION
- Makes mass concentration optional in "add medium" dialog
- Fixes [#1283](https://app.zenhub.com/workspaces/bioviz-scrum-5d22fe4139b1324e0011234c/issues/dd-decaf/scrum/1283)
- Fixes a separate bug: After creating a new medium, compounds were note updated in the store, which caused various problems down the line. Now it behaves like when editing media and compound state is always updated after making changes.