### PR TITLE
refactor: remove all cookies

### DIFF
--- a/src/store/modules/consents.ts
+++ b/src/store/modules/consents.ts
@@ -245,9 +245,7 @@ export default vuexStoreModule({
           category: "preferences"
         });
         if (!consentGiven) {
-          ["jwt", "cookie:accepted", "consents"].forEach(k =>
-            localStorage.removeItem(k)
-          );
+          localStorage.clear();
         }
       });
     },


### PR DESCRIPTION
With analytics, more cookies have been added, so it make more sense to
remove all cookies at once if they cannot be stored on user's machine than doing so selectively.