### PR TITLE
fix: error on updateUser action

### DIFF
--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -317,20 +317,22 @@ export default Vue.extend({
                 // Note: identifyUser and updateUser are not guarded by the
                 // isNewUser check as we want to capture the information even
                 // if it is not the first time the user logged in.
-                if (email) {
-                  this.$store.dispatch("analytics/identifyUser", {
-                    registeredEmail: email
+                const identifyPromise = email
+                  ? this.$store.dispatch("analytics/identifyUser", {
+                      registeredEmail: email
+                    })
+                  : Promise.resolve();
+                identifyPromise.then(() => {
+                  this.$store.dispatch("analytics/updateUser", {
+                    email,
+                    displayName: result.user.displayName,
+                    photoUrl: result.user.photoURL,
+                    phone: result.user.phoneNumber,
+                    username: result.additionalUserInfo.username,
+                    firstName: result.additionalUserInfo.profile.given_name,
+                    lastName: result.additionalUserInfo.profile.family_name,
+                    dateJoined: result.user.metadata.a // creation time timestamp
                   });
-                }
-                this.$store.dispatch("analytics/updateUser", {
-                  email,
-                  displayName: result.user.displayName,
-                  photoUrl: result.user.photoURL,
-                  phone: result.user.phoneNumber,
-                  username: result.additionalUserInfo.username,
-                  firstName: result.additionalUserInfo.profile.given_name,
-                  lastName: result.additionalUserInfo.profile.family_name,
-                  dateJoined: result.user.metadata.a // creation time timestamp
                 });
                 this.$store.dispatch("analytics/login", {
                   signInMethod: providerKey,
@@ -352,14 +354,17 @@ export default Vue.extend({
         message: this.$refs.disclaimer.textContent,
         source: "web"
       });
-      this.$store.dispatch("analytics/identifyUser", {
-        registeredEmail: params.email
-      });
-      this.$store.dispatch("analytics/updateUser", {
-        ...params,
-        password: undefined, // Hide user's password
-        dateJoined: new Date().getTime()
-      });
+      this.$store
+        .dispatch("analytics/identifyUser", {
+          registeredEmail: params.email
+        })
+        .then(() => {
+          this.$store.dispatch("analytics/updateUser", {
+            ...params,
+            password: undefined, // Hide user's password
+            dateJoined: new Date().getTime()
+          });
+        });
       this.$store.dispatch("analytics/login", {
         signInMethod: "email",
         isNewUser: true

--- a/src/store/modules/analytics.ts
+++ b/src/store/modules/analytics.ts
@@ -106,14 +106,17 @@ export default vuexStoreModule({
       state.analytics!.reset();
     },
     async identifyUser({ state }, payload) {
-      const id = await hashMessage(payload.registeredEmail, "SHA-256");
-      state.analytics!.identify(id, {
+      const { registeredEmail, internalId, firebaseId } = payload;
+      const id = registeredEmail
+        ? await hashMessage(registeredEmail, "SHA-256")
+        : internalId || firebaseId;
+      return state.analytics!.identify(id, {
         ...payload,
         registeredEmail: undefined
       });
     },
     updateUser({ state }, payload) {
-      state.analytics!.identify(null, payload);
+      state.analytics!.identify("", payload);
     },
     page({ state }, payload) {
       state.analytics!.page(payload);


### PR DESCRIPTION
Calling analytics.identify with `null` evaluated `null` as valid ID
(error in analytics package). Changing `null` to "" evaluates it
correctly as no ID.
Additionally chained updateUser calls after identifyUser, so the user ID
is always set.